### PR TITLE
Ability to set a single handler for all exceptions that inherit from a base exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ py38venv
 /site
 
 .idea/
+.vscode/
 
 tests/out/
 

--- a/blacksheep/baseapp.pyx
+++ b/blacksheep/baseapp.pyx
@@ -4,6 +4,7 @@ import logging
 from .contents cimport TextContent
 from .exceptions cimport HTTPException
 from .messages cimport Request, Response
+from .utils import get_class_instance_hierarchy
 
 
 async def handle_not_found(app, Request request, HTTPException http_exception):
@@ -105,7 +106,11 @@ cdef class BaseApplication:
         return self.exceptions_handlers.get(http_exception.status, common_http_exception_handler)
 
     cdef object get_exception_handler(self, Exception exception):
-        return self.exceptions_handlers.get(type(exception))
+        for current_class_in_hierarchy in get_class_instance_hierarchy(exception):
+            if current_class_in_hierarchy in self.exceptions_handlers:
+                return self.exceptions_handlers[current_class_in_hierarchy]
+
+        return None
 
     async def handle_internal_server_error(self, Request request, Exception exc):
         if self.show_error_details:

--- a/blacksheep/utils/__init__.py
+++ b/blacksheep/utils/__init__.py
@@ -1,5 +1,7 @@
 import re
-from typing import AnyStr
+from typing import AnyStr, Tuple, Type, TypeVar
+
+T = TypeVar("T")
 
 
 def ensure_bytes(value: AnyStr) -> bytes:
@@ -27,3 +29,11 @@ def join_fragments(*args: AnyStr) -> str:
     return "/" + "/".join(
         remove_duplicate_slashes(ensure_str(arg)).strip("/") for arg in args if arg
     )
+
+
+def get_class_hierarchy(cls: Type[T]) -> Tuple[Type[T], ...]:
+    return cls.__mro__
+
+
+def get_class_instance_hierarchy(instance: T) -> Tuple[Type[T], ...]:
+    return get_class_hierarchy(type(instance))


### PR DESCRIPTION
This is for #188

This enables falling back to the handler of a parent exception if one exists. When an exception inherits from multiple classes, we will for handlers from left to right. 

Example:
```python
class A():
  pass

class B():
  pass

class C(A, B): # If this is raised but doesn't have a handler, we will look for handler for A first and then B.
  pass

class D(B, A): # If this is raised but doesn't have a handler, we will look for handler for B first and then A.
  pass
```

Let me know if you would prefer the helper functions added in utils were in cypthon. This is my first experience with cython so I don't really know what are the trade-offs and what is at stake.