### PR TITLE
Fix ORJSON encode error

### DIFF
--- a/blacksheep/server/responses.py
+++ b/blacksheep/server/responses.py
@@ -177,11 +177,25 @@ def html(value: str, status: int = 200) -> Response:
         status, None, Content(b"text/html; charset=utf-8", value.encode("utf8"))
     )
 
-
 def json(data: Any, status: int = 200) -> Response:
     """
     Returns a response with application/json content,
     and given status (default HTTP 200 OK).
+    """
+    return Response(
+        status,
+        None,
+        Content(
+            b"application/json",
+            json_plugin.dumps(data),
+        ),
+    )
+
+def json_encode(data: Any, status: int = 200) -> Response:
+    """
+    Returns a response with application/json content,
+    and given status (default HTTP 200 OK).
+    Encode the dumps output to bytes.
     """
     return Response(
         status,


### PR DESCRIPTION
Proposal to fix [this issue](https://github.com/Neoteroi/BlackSheep/issues/192).

- Python's JSON returns a `str`, which need to be encoded.
- ORJSON returns a `bytes`, which produce an error when called with `encode('utf-8').

I split the `blacksheep.server.responses.json()` function into two function:
- `json()`, which now only dumps → To use with ORJSON.
- `json_encode()`, which dumps and then encode → Equivalent to the previous implementation of `json()`