### PR TITLE
Bump cchardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 atomicwrites==1.3.0
 attrs==19.3.0
 backcall==0.1.0
-cchardet==2.1.5
+cchardet==2.1.7
 certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4


### PR DESCRIPTION
Only cchardet==2.1.7 supports Python3.9
ref: https://github.com/PyYoshi/cChardet/releases/tag/2.1.7