### PR TITLE
🐛 fix(openapi): fix for optional field for pydantic

### DIFF
--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -204,10 +204,7 @@ class PydanticModelTypeHandler(ObjectTypeHandler):
             )
 
         if value_type == "boolean":
-            return Schema(
-                type=ValueType.BOOLEAN,
-                nullable=nullable
-            )
+            return Schema(type=ValueType.BOOLEAN, nullable=nullable)
 
         if value_type == "file":
             # TODO: improve support for file type,

--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -95,7 +95,11 @@ def check_union(object_type: Any) -> Tuple[bool, Any]:
         hasattr(object_type, "__origin__")
         and object_type.__origin__ is Union
         or _is_union_type(object_type)
+        or (hasattr(object_type, "nullable"))
     ):
+        # For Pydantic
+        if hasattr(object_type, "nullable"):
+            return object_type.nullable, object_type
         # support only Union[None, Type] - that is equivalent of Optional[Type]
         if type(None) not in object_type.__args__ or len(object_type.__args__) > 2:
             raise UnsupportedUnionTypeException(object_type)
@@ -200,7 +204,10 @@ class PydanticModelTypeHandler(ObjectTypeHandler):
             )
 
         if value_type == "boolean":
-            return bool
+            return Schema(
+                type=ValueType.BOOLEAN,
+                nullable=nullable
+            )
 
         if value_type == "file":
             # TODO: improve support for file type,


### PR DESCRIPTION
fix for optional bool field when using BaseModel from Pydantic

Hi @RobertoPrevato, thank you for creating this great web framework.
I opened this PR to fix the problem I met when I was using Pydantic's BaseModel with openapi auto-generated docs.

The situation is like I have a model:
```python
from typing import Dict, List, Optional
from pydantic import AnyHttpUrl, BaseModel

class Params(BaseModel):
    page_url: AnyHttpUrl
    force_refresh: Optional[bool] = False

```
And if I ran the command 
```shell
http http://localhost:8000/openapi.json | jq .components.schemas.Params
```

I'll get
```JSON
{
  "type": "object",
  "required": [
    "page_url",
    "force_refresh"
  ],
  "properties": {
    "page_url": {
      "type": "string",
      "format": "uri",
      "maxLength": 65536,
      "minLength": 1,
      "nullable": false
    },
    "force_refresh": {
      "type": "boolean",
      "nullable": false
    }
  }
}
```
which is not correct because **force_refresh** should be optional.
After the modification I made, with the same command the result looks correct:
```JSON
{
  "type": "object",
  "required": [
    "page_url"
  ],
  "properties": {
    "page_url": {
      "type": "string",
      "format": "uri",
      "maxLength": 65536,
      "minLength": 1,
      "nullable": false
    },
    "force_refresh": {
      "type": "boolean",
      "nullable": true
    }
  }
}
```