### PR TITLE
Add description for tags

### DIFF
--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -24,6 +24,7 @@ from openapidocs.v3 import (
     PathItem,
     Reference,
     RequestBody,
+    Tag,
 )
 from openapidocs.v3 import Response as ResponseDoc
 from openapidocs.v3 import Schema, Server, ValueFormat, ValueType
@@ -278,6 +279,7 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
         yaml_spec_path: str = "/openapi.yaml",
         preferred_format: Format = Format.JSON,
         anonymous_access: bool = True,
+        tags: Optional[List[Tag]] = None,
     ) -> None:
         super().__init__(
             ui_path=ui_path,
@@ -287,6 +289,7 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
             anonymous_access=anonymous_access,
         )
         self.info = info
+        self._tags = tags
         self.components = Components()
         self._objects_references: Dict[Any, Reference] = {}
         self.servers: List[Server] = []
@@ -309,7 +312,10 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
     def generate_documentation(self, app: Application) -> OpenAPI:
         self._optimize_binders_docs()
         return OpenAPI(
-            info=self.info, paths=self.get_paths(app), components=self.components
+            info=self.info,
+            paths=self.get_paths(app),
+            components=self.components,
+            tags=self._tags,
         )
 
     def get_paths(self, app: Application, path_prefix: str = "") -> Dict[str, PathItem]:

--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -308,13 +308,37 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
     def get_ui_page_title(self) -> str:
         return self.info.title
 
+    def _iter_tags(self, paths: Dict[str, PathItem]) -> Iterable[str]:
+        methods = (
+            "get",
+            "post",
+            "put",
+            "delete",
+            "options",
+            "head",
+            "patch",
+            "trace",
+        )
+
+        for path in paths.values():
+            for method in methods:
+                prop: Optional[Operation] = getattr(path, method)
+
+                if prop is not None and prop.tags is not None:
+                    yield from prop.tags
+
+    def _tags_from_paths(self, paths: Dict[str, PathItem]) -> List[Tag]:
+        unique_tags = set(self._iter_tags(paths))
+        return [Tag(name=name) for name in sorted(unique_tags)]
+
     def generate_documentation(self, app: Application) -> OpenAPI:
         self._optimize_binders_docs()
+        paths = self.get_paths(app)
         return OpenAPI(
             info=self.info,
-            paths=self.get_paths(app),
+            paths=paths,
             components=self.components,
-            tags=self._tags,
+            tags=self._tags or self._tags_from_paths(paths),
         )
 
     def get_paths(self, app: Application, path_prefix: str = "") -> Dict[str, PathItem]:

--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -24,10 +24,9 @@ from openapidocs.v3 import (
     PathItem,
     Reference,
     RequestBody,
-    Tag,
 )
 from openapidocs.v3 import Response as ResponseDoc
-from openapidocs.v3 import Schema, Server, ValueFormat, ValueType
+from openapidocs.v3 import Schema, Server, Tag, ValueFormat, ValueType
 
 from blacksheep.server.bindings import (
     Binder,


### PR DESCRIPTION
Tags ordering can be handled via tags description field [1]

```python

docs = OpenAPIHandler(
    info=Info(title="Example API", version="0.0.1"),
    tags=[
        Tag(name="Users"),
        Tag(name="Favorites"),
        Tag(name="Reactions"),
        Tag(name="Topics"),
        Tag(name="Reviews"),
        Tag(name="Comments"),
    ],
)
docs.bind_app(app)


```

For example, if a project has autogenerated tags in terms of using ApiController. OpenAPIHandler will automatically sort tags alphabetically.


```python
from dataclasses import dataclass

from blacksheep import Application
from blacksheep.server.controllers import APIController, get, post
from blacksheep.server.openapi.v3 import OpenAPIHandler
from openapidocs.v3 import Info

app = Application()

docs = OpenAPIHandler(info=Info(title="Example API", version="0.0.1"))
docs.bind_app(app)


@dataclass
class Cat:
    pass


@dataclass
class Dog:
    pass


@dataclass
class Parrot:
    pass


class Cats(APIController):
    @get()
    def get_cats(self) -> list[Cat]:
        """Return the list of configured cats."""

    @post()
    def create_cat(self, cat: Cat) -> None:
        """Add a Cat to the system."""


class Dogs(APIController):
    @get()
    def get_dogs(self) -> list[Dog]:
        """Return the list of configured dogs."""

    @post()
    def create_dog(self, dog: Dog) -> None:
        """Add a Dog to the system."""


class Parrots(APIController):
    @get()
    def get_parrots(self) -> list[Parrot]:
        """Return the list of configured Parrots."""

    @post()
    def create_parrot(self, parrot: Parrot) -> None:
        """Add a Parrot to the system."""
```

1 - https://swagger.io/docs/specification/grouping-operations-with-tags/

Issue: #327 