### PR TITLE
Fix #331

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install cython==0.29.32 --install-option="--no-cython-compile"
+          pip install cython==0.29.34
           pip install -r requirements.txt
           pip install flake8
 
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -87,27 +87,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v1
-        id: depcache
-        with:
-          path: deps
-          key: requirements-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-
-      - name: Download dependencies
-        if: steps.depcache.outputs.cache-hit != 'true'
-        run: |
-          pip download --dest=deps -r requirements.txt
-
       - name: Install dependencies
         run: |
-          PYVER=`python -V 2>&1`
-
-          if [ "${PYVER:0:-2}" == "Python 3.10" ]; then
-            pip install -r requirements.txt
-          else
-            pip install -U --no-index --find-links=deps deps/*
-          fi
-
+          pip install -r requirements.txt
           pip install black isort flake8
 
       - name: Compile Cython extensions
@@ -175,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -190,7 +172,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          pip install cython --install-option="--no-cython-compile"
+          pip install cython
           python -m pip install --upgrade setuptools pip wheel
 
       - name: Compile Cython extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.14] - 2023-04-23 :face_with_head_bandage:
+
+- Fix #331; (impossibility to install with Python 3.10 and 3.11 with latest
+  `pip` because of `cchardet` not distributing compiled wheels and breaking
+  change in `pip` minor version); contributed by @mementum.
+- Upgrades dependencies.
+- Removes Python 3.7 from build matrix.
 
 ## [1.2.13] - 2023-04-17 :crown:
 

--- a/blacksheep/messages.pyx
+++ b/blacksheep/messages.pyx
@@ -4,10 +4,7 @@ from datetime import datetime, timedelta
 from json.decoder import JSONDecodeError
 from urllib.parse import parse_qs, quote, unquote
 
-try:
-    import cchardet as chardet
-except ImportError:
-    import chardet
+import charset_normalizer
 
 from blacksheep.multipart import parse_multipart
 from blacksheep.plugins import json as json_plugin
@@ -153,8 +150,8 @@ cdef class Message:
                 try:
                     return body.decode('ISO-8859-1')
                 except UnicodeDecodeError:
-                    # fallback to chardet;
-                    return body.decode(chardet.detect(body)['encoding'])
+                    # fallback to trying to detect the encoding;
+                    return body.decode(charset_normalizer.detect(body)['encoding'])
 
     async def form(self):
         cdef str text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,15 @@
 asgiref==3.5.2
 attrs==22.1.0
-cchardet==2.1.7; python_version < '3.11'
 certifi==2022.12.7
 cffi==1.15.1
-chardet==3.0.4
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
 click==8.1.3
 coverage==6.5.0
-cryptography==38.0.1
-Cython==0.29.32; platform_system != "Windows"
+cryptography==40.0.2
+Cython==0.29.34; platform_system != "Windows"
 essentials==1.1.5
-essentials-openapi==1.0.5
-Flask==2.2.2
+essentials-openapi==1.0.6
+Flask==2.2.3
 gevent==22.10.1
 greenlet==1.1.3.post0
 guardpost==0.0.9
@@ -25,7 +23,7 @@ idna==3.4
 iniconfig==1.1.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
-MarkupSafe==2.1.1
+MarkupSafe==2.1.2
 mccabe==0.6.1
 packaging==21.3
 pluggy==1.0.0
@@ -35,22 +33,22 @@ pycparser==2.21
 pydantic==1.10.2
 PyJWT==2.6.0
 pyparsing==3.0.9
-pytest==7.1.3
+pytest==7.3.1
 pytest-asyncio==0.20.1
 pytest-cov==4.0.0
 python-dateutil==2.8.2
 PyYAML==6.0
-regex==2020.4.4
-requests==2.28.1
 rodi==1.1.3
+regex==2023.3.23
+requests==2.28.2
 six==1.16.0
 toml==0.10.1
 tomli==2.0.1
 typing_extensions==4.4.0
 urllib3==1.26.12
-uvicorn==0.19.0
+uvicorn==0.21.1
 wcwidth==0.2.5
-websockets==10.3
+websockets==11.0.2
 Werkzeug==2.2.2
 wsproto==1.2.0
 zope.event==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ COMPILE_ARGS = ["-O2"]
 
 setup(
     name="blacksheep",
-    version="1.2.13",
+    version="1.2.14",
     description="Fast web framework for Python asyncio",
     long_description=readme(),
     long_description_content_type="text/markdown",
@@ -98,8 +98,7 @@ setup(
         "httptools>=0.5",
         "Jinja2~=3.1.2",
         "certifi>=2022.12.7",
-        "cchardet~=2.1.7; python_version < '3.11'",
-        "chardet==5.0.0; python_version > '3.10'",
+        "charset-normalizer~=3.1.0",
         "guardpost~=0.0.9",
         "rodi~=1.1.1",
         "essentials>=1.1.4,<2.0",


### PR DESCRIPTION
- Fix #331; (impossibility to install with Python 3.10 and 3.11 with latest
  `pip` because of `cchardet` not distributing compiled wheels and breaking
  change in `pip` minor version); contributed by @mementum.
- Upgrades dependencies.
- Removes Python 3.7 from build matrix.