### PR TITLE
Support security defenition in OpenAPI docs

### DIFF
--- a/blacksheep/server/openapi/common.py
+++ b/blacksheep/server/openapi/common.py
@@ -101,6 +101,12 @@ class ResponseInfo:
     content: Optional[List[ContentInfo]] = None
 
 
+@dataclass
+class SecurityInfo:
+    name: str
+    value: List[str]
+
+
 ResponseStatusType = Union[int, str, HTTPStatus]
 
 
@@ -123,6 +129,7 @@ class EndpointDocs:
     ignored: Optional[bool] = None
     deprecated: Optional[bool] = None
     on_created: Optional[Callable[[Any, Any], None]] = None
+    security: Optional[List[SecurityInfo]] = None
 
 
 OpenAPIRootType = TypeVar("OpenAPIRootType", bound=OpenAPIRoot)
@@ -188,6 +195,7 @@ class APIDocsHandler(Generic[OpenAPIRootType], ABC):
         ignored: Optional[bool] = None,
         deprecated: Optional[bool] = None,
         on_created: Optional[Callable[[Any, Any], None]] = None,
+        security: Optional[List[SecurityInfo]] = None,
     ) -> Any:
         def decorator(fn):
             if doc:
@@ -204,6 +212,7 @@ class APIDocsHandler(Generic[OpenAPIRootType], ABC):
                 ignored=ignored,
                 deprecated=deprecated,
                 on_created=on_created,
+                security=security,
             )
             return fn
 


### PR DESCRIPTION
Add to APIDocsHandler __call__ security parameter

```python
    @docs(
        security=[
            SecurityInfo("basicAuth", []),
            SecurityInfo("bearerAuth", ["read:home", "write:home"]),
        ]
    )
```

Add to OpenAPIHandler constructor security_schemes parameter

```python
    docs = OpenAPIHandler(
        info=Info(
            title="Example API",
            version="0.0.1",
        ),
        security_schemes={
            "oauth2": OAuth2Security(
                flows=OAuthFlows(
                    implicit=OAuthFlow(
                        authorization_url="https://example.com/oauth2/authorize",
                        token_url="https://example.com/oauth2/token",
                        refresh_url="https://example.com/oauth2/refresh",
                        scopes={
                            "read:cats": "Read your cats",
                            "write:cats": "Write your cats",
                        },
                    )
                ),
                description="OAuth2 Auth",
            ),
        },
    )
```

OpenAPI documentation - https://swagger.io/docs/specification/authentication/