### PR TITLE
`StreamedContent` integer overflow fix

### DIFF
--- a/blacksheep/contents.pxd
+++ b/blacksheep/contents.pxd
@@ -3,12 +3,13 @@
 #
 # This module is part of BlackSheep and is released under
 # the MIT License https://opensource.org/licenses/MIT
+import cython
 
 
 cdef class Content:
     cdef readonly bytes type
     cdef readonly bytes body
-    cdef readonly int length
+    cdef readonly cython.long length
 
 
 cdef class StreamedContent(Content):

--- a/blacksheep/contents.pyi
+++ b/blacksheep/contents.pyi
@@ -1,3 +1,4 @@
+import cython
 import uuid
 from typing import Any, AsyncIterable, Callable, Dict, List, Optional, Tuple, Union
 
@@ -15,7 +16,7 @@ class StreamedContent(Content):
         self,
         content_type: bytes,
         data_provider: Callable[[], AsyncIterable[bytes]],
-        data_length: int = -1,
+        data_length: cython.long = -1,
     ) -> None:
         self.type = content_type
         self.body = None

--- a/blacksheep/contents.pyx
+++ b/blacksheep/contents.pyx
@@ -1,3 +1,4 @@
+import cython
 import json
 import uuid
 from collections.abc import MutableSequence
@@ -29,7 +30,7 @@ cdef class StreamedContent(Content):
         self,
         bytes content_type,
         object data_provider,
-        int data_length = -1
+        cython.long data_length = -1
     ):
         self.type = content_type
         self.body = None


### PR DESCRIPTION
Closes #394

Changed datatype of `StreamedContent.length` to `cyphon.long`, as well as constructor argument `data_length`.