### PR TITLE
add: support for jinja ext

### DIFF
--- a/blacksheep/server/rendering/jinja2.py
+++ b/blacksheep/server/rendering/jinja2.py
@@ -14,7 +14,7 @@ from .abc import Renderer
 
 @lru_cache(1200)
 def get_template_name(name: str) -> str:
-    if not name.endswith(".html"):
+    if not name.endswith(".html") and not name.endswith(".jinja"):
         return name + ".html"
     return name
 
@@ -93,7 +93,7 @@ class JinjaRenderer(Renderer):
                 os.environ.get("APP_JINJA_PACKAGE_NAME", "app"),
                 os.environ.get("APP_JINJA_PACKAGE_PATH", "views"),
             ),
-            autoescape=select_autoescape(["html", "xml"]),
+            autoescape=select_autoescape(["html", "xml", "jinja"]),
             auto_reload=bool(os.environ.get("APP_JINJA_DEBUG", "")) or debug,
             enable_async=bool(os.environ.get("APP_JINJA_ENABLE_ASYNC", ""))
             or enable_async,

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -324,6 +324,8 @@ async def test_controller_conventional_view_name_extraneous_function(home_model)
     [
         ("index", "index.html"),
         ("index.html", "index.html"),
+        ("index.html.jinja", "index.html.jinja"),
+        ("index.jinja", "index.jinja"),
         ("default", "default.html"),
     ],
 )


### PR DESCRIPTION
Many editors and tools look for the `.html.jinja` extension in order to provide formatting, color highlighting, styling, intellisense, etc. To support those use cases, don't try to append the `.html` extension to templates that already specify the `.jinja` extension, and also do autoescaping for `.jinja` files.

I'm also open to making it ignore only `.html.jinja` instead of just `.jinja`, but that would force folks into using `.jinja.html` instead, which feels like an incorrect ext.