### PR TITLE
Fix/v201

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
       - "*"
     paths-ignore:
       - README.md
+      - CHANGELOG.md
 
 env:
   PROJECT_NAME: blacksheep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes #441 causing the refresh_token endpoint for OpenID Connect integrations
   to not work when an authenticated user is required by default.
 - Fixes #427 handling WebSocket errors according to ASGI specification.
+- Fixes #443, raising a detailed exception when more than one application is
+  sharing the same instance of `Router`
+- Fixes #438 and #436, restoring support for `uvicorn` used programmatically
+  and reloading the application object more than once in the same process.
 
 ## [2.0.0] - 2023-11-18 :mage_man:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixes #441 causing the `refresh_token` endpoint for OpenID Connect
   integrations to not work when an authenticated user is required by default.
-- Fixes #427 handling WebSocket errors according to ASGI specification.
+- Fixes #427, handling WebSocket errors according to ASGI specification.
 - Fixes #443, raising a detailed exception when more than one application is
   sharing the same instance of `Router`
 - Fixes #438 and #436, restoring support for `uvicorn` used programmatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.1] - 2023-12-09 :mount_fuji:
 
 - Fixes #441 causing the `refresh_token` endpoint for OpenID Connect
-  integrations to not work when an authenticated user is required by default.
+  integrations to not work when authentication is required by default.
 - Fixes #427, handling WebSocket errors according to ASGI specification.
 - Fixes #443, raising a detailed exception when more than one application is
   sharing the same instance of `Router`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.1] - 2023-12-09 :mount_fuji:
 
-- Fixes #441 causing the refresh_token endpoint for OpenID Connect integrations
-  to not work when an authenticated user is required by default.
+- Fixes #441 causing the `refresh_token` endpoint for OpenID Connect
+  integrations to not work when an authenticated user is required by default.
 - Fixes #427 handling WebSocket errors according to ASGI specification.
 - Fixes #443, raising a detailed exception when more than one application is
   sharing the same instance of `Router`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixes #441 causing the refresh_token endpoint for OpenID Connect integrations
   to not work when an authenticated user is required by default.
-
+- Fixes #427 handling WebSocket errors according to ASGI specification.
 
 ## [2.0.0] - 2023-11-18 :mage_man:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2023-12-09 :mount_fuji:
+
+- Fixes #441 causing the refresh_token endpoint for OpenID Connect integrations
+  to not work when an authenticated user is required by default.
+
+
 ## [2.0.0] - 2023-11-18 :mage_man:
 
 - Releases v2 as stable.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Roberto Prevato
+Copyright (c) 2021-present Roberto Prevato roberto.prevato@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/blacksheep/__init__.py
+++ b/blacksheep/__init__.py
@@ -3,7 +3,7 @@ Root module of the framework. This module re-exports the most commonly
 used types to reduce the verbosity of the imports statements.
 """
 __author__ = "Roberto Prevato <roberto.prevato@gmail.com>"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 from .contents import Content as Content
 from .contents import FormContent as FormContent

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -191,7 +191,7 @@ class Application(BaseApplication):
             mount = MountRegistry(env_settings.mount_auto_events)
 
         super().__init__(show_error_details or env_settings.show_error_details, router)
-        validate_router(self)
+
         assert services is not None
         self._services: ContainerProtocol = services
         self.middlewares: List[Callable[..., Awaitable[Response]]] = []
@@ -211,6 +211,8 @@ class Application(BaseApplication):
         self._session_middleware: Optional[SessionMiddleware] = None
         self.base_path: str = ""
         self._mount_registry = mount
+
+        validate_router(self)
         parent_file = get_parent_file()
 
         if parent_file:

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -65,6 +65,7 @@ from blacksheep.server.routing import (
     RoutesRegistry,
 )
 from blacksheep.server.routing import router as default_router
+from blacksheep.server.routing import validate_router
 from blacksheep.server.websocket import WebSocket
 from blacksheep.sessions import SessionMiddleware, SessionSerializer
 from blacksheep.settings.di import di_settings
@@ -188,8 +189,9 @@ class Application(BaseApplication):
             services = di_settings.get_default_container()
         if mount is None:
             mount = MountRegistry(env_settings.mount_auto_events)
-        super().__init__(show_error_details or env_settings.show_error_details, router)
 
+        super().__init__(show_error_details or env_settings.show_error_details, router)
+        validate_router(self)
         assert services is not None
         self._services: ContainerProtocol = services
         self.middlewares: List[Callable[..., Awaitable[Response]]] = []

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -49,7 +49,6 @@ from blacksheep.server.authorization import (
     handle_unauthorized,
 )
 from blacksheep.server.bindings import ControllerParameter
-from blacksheep.server.controllers import router as controllers_router
 from blacksheep.server.cors import CORSPolicy, CORSStrategy, get_cors_middleware
 from blacksheep.server.env import EnvironmentSettings
 from blacksheep.server.errors import ServerErrorDetailsHandler
@@ -205,7 +204,6 @@ class Application(BaseApplication):
         self.on_stop = ApplicationEvent(self)
         self.on_middlewares_configuration = ApplicationSyncEvent(self)
         self.started = False
-        self.controllers_router: RoutesRegistry = controllers_router
         self.files_handler = FilesHandler()
         self.server_error_details_handler = ServerErrorDetailsHandler()
         self._session_middleware: Optional[SessionMiddleware] = None
@@ -218,6 +216,14 @@ class Application(BaseApplication):
         if parent_file:
             _auto_import_controllers(parent_file)
             _auto_import_routes(parent_file)
+
+    @property
+    def controllers_router(self) -> RoutesRegistry:
+        return self.router.controllers_routes
+
+    @controllers_router.setter
+    def controllers_router(self, value) -> None:
+        self.router.controllers_routes = value
 
     @property
     def services(self) -> ContainerProtocol:

--- a/blacksheep/server/authentication/oidc.py
+++ b/blacksheep/server/authentication/oidc.py
@@ -1062,6 +1062,7 @@ def use_openid_connect(
                 cookie_name=scheme_name.lower(), auth_scheme=scheme_name
             ),
         )
+
     app.use_authentication().add(auth_handler)
 
     handler = OpenIDConnectHandler(
@@ -1087,6 +1088,7 @@ def use_openid_connect(
     async def redirect_to_logout(request: Request):
         return await handler.handle_logout_redirect(request)
 
+    @allow_anonymous()
     @app.router.post(settings.refresh_token_path)
     @cache_control(no_cache=True, no_store=True)
     async def refresh_token(request: Request):

--- a/blacksheep/server/controllers.py
+++ b/blacksheep/server/controllers.py
@@ -38,14 +38,19 @@ from blacksheep.server.responses import (
     view,
     view_async,
 )
-from blacksheep.server.routing import RouteFilter, RoutesRegistry, normalize_filters
+from blacksheep.server.routing import (
+    RouteFilter,
+    RoutesRegistry as RoutesRegistry,
+    normalize_filters,
+    controllers_routes,
+)
 from blacksheep.utils import AnyStr, join_fragments
 
 # singleton router used to store initial configuration,
 # before the application starts
 # this is used as *default* router for controllers, but it can be overridden
 # - see for example tests in test_controllers
-router = RoutesRegistry()
+router = controllers_routes
 
 
 head = router.head

--- a/blacksheep/server/controllers.py
+++ b/blacksheep/server/controllers.py
@@ -38,12 +38,9 @@ from blacksheep.server.responses import (
     view,
     view_async,
 )
-from blacksheep.server.routing import (
-    RouteFilter,
-    RoutesRegistry as RoutesRegistry,
-    normalize_filters,
-    controllers_routes,
-)
+from blacksheep.server.routing import RouteFilter
+from blacksheep.server.routing import RoutesRegistry as RoutesRegistry  # noqa
+from blacksheep.server.routing import controllers_routes, normalize_filters
 from blacksheep.utils import AnyStr, join_fragments
 
 # singleton router used to store initial configuration,

--- a/blacksheep/server/websocket.py
+++ b/blacksheep/server/websocket.py
@@ -62,10 +62,19 @@ class WebSocket(Request):
         self.scope = scope  # type: ignore
         self._receive = self._wrap_receive(receive)
         self._send = send
+        self._accepted = False
         self.route_values = {}
 
         self.client_state = WebSocketState.CONNECTING
         self.application_state = WebSocketState.CONNECTING
+
+    @property
+    def accepted(self) -> bool:
+        """
+        Returns a value indicating whether this WebSocket request was already accepted,
+        or if it is still in the HTTP handshake phase.
+        """
+        return self._accepted
 
     def __repr__(self):
         return f"<WebSocket {self.url.value.decode()}>"
@@ -83,11 +92,12 @@ class WebSocket(Request):
         self.client_state = WebSocketState.CONNECTED
 
     async def accept(
-        self, headers: Optional[List] = None, subprotocol: str = None
+        self, headers: Optional[List] = None, subprotocol: Optional[str] = None
     ) -> None:
         headers = headers or []
 
         await self._connect()
+        self._accepted = True
         self.application_state = WebSocketState.CONNECTED
 
         message = {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -37,6 +37,7 @@ from blacksheep.server.normalization import ensure_response
 from blacksheep.server.openapi.v3 import OpenAPIHandler
 from blacksheep.server.resources import get_resource_file_path
 from blacksheep.server.responses import status_code, text
+from blacksheep.server.routing import Router, SharedRouterError
 from blacksheep.server.security.hsts import HSTSMiddleware
 from blacksheep.testing.helpers import get_example_scope
 from blacksheep.testing.messages import MockReceive, MockSend
@@ -4131,3 +4132,14 @@ async def test_lifespan_event(app: Application):
 
     assert initialized is True
     assert disposed is True
+
+
+def test_mounting_apps_using_the_same_router_raises_error():
+    # Recreates the scenario happening when the default singleton router is used for
+    # both parent app and child app
+    # https://github.com/Neoteroi/BlackSheep/issues/443
+    single_router = Router()
+    Application(router=single_router)
+
+    with pytest.raises(SharedRouterError):
+        Application(router=single_router)


### PR DESCRIPTION
- Fixes #441 causing the `refresh_token` endpoint for OpenID Connect
  integrations to not work when an authenticated user is required by default.
- Fixes #427, handling WebSocket errors according to ASGI specification.
- Fixes #443, raising a detailed exception when more than one application is
  sharing the same instance of `Router`
- Fixes #438 and #436, restoring support for `uvicorn` used programmatically
  and reloading the application object more than once in the same process.