### PR TITLE
Fix WS exception handling

### DIFF
--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -64,7 +64,7 @@ from blacksheep.server.routing import (
 )
 from blacksheep.server.routing import router as default_router
 from blacksheep.server.routing import validate_router
-from blacksheep.server.websocket import WebSocket
+from blacksheep.server.websocket import WebSocket, format_reason
 from blacksheep.sessions import SessionMiddleware, SessionSerializer
 from blacksheep.settings.di import di_settings
 from blacksheep.utils import ensure_bytes, join_fragments
@@ -749,7 +749,7 @@ class Application(BaseApplication):
             # If WebSocket connection accepted, close
             # the connection using WebSocket Internal error code.
             if ws.accepted:
-                return await ws.close(1011, reason=str(exc))
+                return await ws.close(1011, reason=format_reason(str(exc)))
 
             # Otherwise, just close the connection, the ASGI server
             # will anyway respond 403 to the client.

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -746,6 +746,7 @@ class Application(BaseApplication):
         try:
             return await route.handler(ws)
         except Exception as exc:
+            logging.exception("Exception while handling WebSocket")
             # If WebSocket connection accepted, close
             # the connection using WebSocket Internal error code.
             if ws.accepted:

--- a/blacksheep/server/websocket.py
+++ b/blacksheep/server/websocket.py
@@ -6,6 +6,8 @@ from blacksheep.messages import Request
 from blacksheep.server.asgi import get_full_path
 from blacksheep.settings.json import json_settings
 
+MAX_REASON_SIZE = 123
+
 
 class WebSocketState(Enum):
     CONNECTING = 0
@@ -180,3 +182,18 @@ class WebSocket(Request):
 
     async def close(self, code: int = 1000, reason: Optional[str] = None) -> None:
         await self._send({"type": "websocket.close", "code": code, "reason": reason})
+
+
+def format_reason(reason: str) -> str:
+    """
+    Ensures that the close reason is no longer than the max reason size.
+    (https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#reason)
+    """
+    reason_bytes = reason.encode()
+
+    if len(reason_bytes) <= MAX_REASON_SIZE:
+        return reason
+
+    ellipsis_ = b"..."
+    truncated_reason = reason_bytes[: MAX_REASON_SIZE - len(ellipsis_)] + ellipsis_
+    return truncated_reason.decode()

--- a/itests/app_2.py
+++ b/itests/app_2.py
@@ -17,7 +17,6 @@ from openapidocs.v3 import Schema
 from pydantic import BaseModel
 
 from blacksheep import Response, TextContent, WebSocket
-from blacksheep.exceptions import BadRequest
 from blacksheep.server import Application
 from blacksheep.server.authentication import AuthenticationHandler
 from blacksheep.server.authorization import Policy, Requirement, auth
@@ -150,9 +149,15 @@ async def echo_text_admin_users(websocket: WebSocket):
         await websocket.send_text(msg)
 
 
-@app_2.router.ws("/websocket-echo-text-http-exp")
+@app_2.router.ws("/websocket-error-before-accept")
 async def echo_text_http_exp(websocket: WebSocket):
-    raise BadRequest("Example")
+    raise RuntimeError("Error before accept")
+
+
+@app_2.router.ws("/websocket-server-error")
+async def websocket_server_error(websocket: WebSocket):
+    await websocket.accept()
+    raise RuntimeError("Server error")
 
 
 @auth("authenticated")

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -7,6 +7,7 @@ from blacksheep.server.websocket import (
     WebSocket,
     WebSocketDisconnectError,
     WebSocketState,
+    format_reason,
 )
 from blacksheep.testing.messages import MockReceive, MockSend
 from tests.utils.application import FakeApplication
@@ -442,3 +443,21 @@ async def test_application_websocket_binding_by_type_annotation():
         mock_receive,
         mock_send,
     )
+
+
+LONG_REASON = "WRY" * 41
+QIN = "秦"  # Qyn dynasty in Chinese, 3 bytes.
+TOO_LONG_REASON = QIN * 42
+TOO_LONG_REASON_TRUNC = TOO_LONG_REASON[:40] + "..."
+
+
+@pytest.mark.parametrize(
+    "inp,out",
+    [
+        ("Short reason", "Short reason"),
+        (LONG_REASON, LONG_REASON),
+        (TOO_LONG_REASON, TOO_LONG_REASON_TRUNC),
+    ],
+)
+def test_format_reason(inp, out):
+    assert format_reason(inp) == out


### PR DESCRIPTION
@RobertoPrevato After some considerations, I decided to try this approach. Please, let me know, what you think about it. Is it good enough to you?

1. No matching WebSocket path? Close the connection, the ASGI server will respond with 403.
2. An exception raised during handshake? Close the connection, the ASGI server will respond with 403.
3. An exception raised after handshake? Close the connection with code 1011 (which seems to be equivalent to Internal Server Error, see https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1). We return the error reason too, but we take care to truncate it to prevent `control frame too long` errors.

We had a discussion about responding with a more precise status code if the connection was closed before accept, but it seems to be impossible in the ASGI framework. We are not in control of the initial HTTP request, so to speak. We cannot make the protocol server reject the connection with a status code different to 403, and if we try to pass an HTTP status code as a WebSocket close code, it just won't work. Clients and servers like Uvicorn/Daphne will only see this as an invalid WebSocket code.