### PR TITLE
Fix #455 and improve the normalization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removes `consts.pxi` because it used a deprecated Cython feature.
 - Upgrades the versions of Hypercorn and uvicorn for integration tests.
 - Removes the unused "active" property defined in the `Response` class.
+- Fixes #455, reported by @Klavionik. This error caused the WebSocket handler
+  to erroneously return an instance of BlackSheep response to the underlying
+  ASGI server, causing an error to be logged in the console.
+- Update type annotations in the `Application` class code to be more explicit
+  about the fact that certain methods must return None (return in __call__ is
+  used to interrupt code execution and not to return objects).
+- Improve the normalization logic to not normalize the output for WebSocket
+  requests (as ASGI servers do not allow controlling the response for WebSocket
+  handshake requests).
+- Improve the normalization logic to not normalize request handlers that are
+  valid as they are, as asynchronous functions with a single parameter
+  annotated as Request or WebSocket.
 
 ## [2.0.3] - 2023-12-18 :gift:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for Cython code.
 - Removes `consts.pxi` because it used a deprecated Cython feature.
 - Upgrades the versions of Hypercorn and uvicorn for integration tests.
+- Removes the unused "active" property defined in the `Response` class.
 
 ## [2.0.3] - 2023-12-18 :gift:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Meaning that it is easy to integrate with services such as:
 * [Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/overview)
 * [Okta](https://www.okta.com)
 
-Refer to the documentation for more details and examples.
+Refer to the documentation and to [BlackSheep-Examples](https://github.com/Neoteroi/BlackSheep-Examples)
+for more details and examples.
 
 ## Web framework features
 
@@ -260,8 +261,6 @@ from blacksheep.client import ClientSession
 async def client_example():
     async with ClientSession() as client:
         response = await client.get("https://docs.python.org/3/")
-
-        assert response is not None
         text = await response.text()
         print(text)
 

--- a/blacksheep/messages.pxd
+++ b/blacksheep/messages.pxd
@@ -58,7 +58,6 @@ cdef class Request(Message):
 
 cdef class Response(Message):
     cdef public int status
-    cdef public bint active
     cdef dict __dict__
 
     cpdef bint is_redirect(self)

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -627,11 +627,11 @@ class Application(BaseApplication):
 
         self.router.sort_routes()
 
-        for route in self.router:
+        for method, route in self.router.iter_with_methods():
             if route.handler in configured_handlers:
                 continue
 
-            route.handler = normalize_handler(route, self.services)
+            route.handler = normalize_handler(route, self.services, method)
             configured_handlers.add(route.handler)
 
         self._normalize_fallback_route()

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -713,7 +713,7 @@ class Application(BaseApplication):
         await self.on_stop.fire()
         self.started = False
 
-    async def _handle_lifespan(self, receive, send):
+    async def _handle_lifespan(self, receive, send) -> None:
         message = await receive()
         assert message["type"] == "lifespan.startup"
 
@@ -731,7 +731,7 @@ class Application(BaseApplication):
         await self.stop()
         await send({"type": "lifespan.shutdown.complete"})
 
-    async def _handle_websocket(self, scope, receive, send):
+    async def _handle_websocket(self, scope, receive, send) -> None:
         ws = WebSocket(scope, receive, send)
         # TODO: support filters
         route = self.router.get_match_by_method_and_path(
@@ -739,24 +739,27 @@ class Application(BaseApplication):
         )
 
         if route is None:
-            return await ws.close()
+            await ws.close()
+            return
 
         ws.route_values = route.values
 
         try:
-            return await route.handler(ws)
+            # The ASGI protocol does not allow to return any response, not even for the
+            # handshake HTTP request
+            await route.handler(ws)
         except Exception as exc:
             logging.exception("Exception while handling WebSocket")
             # If WebSocket connection accepted, close
             # the connection using WebSocket Internal error code.
             if ws.accepted:
-                return await ws.close(1011, reason=format_reason(str(exc)))
+                await ws.close(1011, reason=format_reason(str(exc)))
+            else:
+                # Otherwise, just close the connection, the ASGI server
+                # will anyway respond 403 to the client.
+                await ws.close()
 
-            # Otherwise, just close the connection, the ASGI server
-            # will anyway respond 403 to the client.
-            return await ws.close()
-
-    async def _handle_http(self, scope, receive, send):
+    async def _handle_http(self, scope, receive, send) -> None:
         assert scope["type"] == "http"
 
         request = Request.incoming(

--- a/blacksheep/server/routing.py
+++ b/blacksheep/server/routing.py
@@ -681,6 +681,17 @@ class Router(RouterBase):
         if self._fallback:
             yield self._fallback
 
+    def iter_with_methods(self):
+        """
+        Iters through the routes defined in this Router, yielding each route
+        and its HTTP method.
+        """
+        for method, routes in self.routes.items():
+            for route in routes:
+                yield method.decode(), route
+        if self._fallback:
+            yield "*", self._fallback
+
     def _is_route_configured(self, method: bytes, route: Route):
         if isinstance(route, FilterRoute):  # pragma: no cover
             # The route defines action filters, we cannot determine if the user is

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -445,6 +445,27 @@ async def test_application_websocket_binding_by_type_annotation():
     )
 
 
+@pytest.mark.asyncio
+async def test_websocket_handler_must_not_return():
+    """
+    This test verifies that normalized request handlers handling WebSockets are not
+    normalized to return an instance of Response.
+    """
+    app = FakeApplication()
+
+    @app.router.ws("/ws")
+    async def websocket_handler(my_ws: WebSocket):
+        pass
+
+    await app.start()
+
+    # Because the defined handler is asynchronous and accepts a WebSocket,
+    # it should not be normalized and kept as-is
+    for route in app.router:
+        assert route.handler is websocket_handler
+        assert await route.handler(...) is None
+
+
 LONG_REASON = "WRY" * 41
 QIN = "秦"  # Qyn dynasty in Chinese, 3 bytes.
 TOO_LONG_REASON = QIN * 42


### PR DESCRIPTION
- Removes the unused "active" property defined in the `Response` class.
- Fixes #455, reported by @Klavionik. This error caused the WebSocket handler to erroneously return an instance of BlackSheep response to the underlying ASGI server, causing an error to be logged in the console.
- Update type annotations in the `Application` class code to be more explicit about the fact that certain methods must return None (return in __call__ is used to interrupt code execution and not to return objects).
- Improve the normalization logic to not normalize the output for WebSocket requests (as ASGI servers do not allow controlling the response for WebSocket handshake requests).
- Improve the normalization logic to not normalize request handlers that are valid as they are, as asynchronous functions with a single parameter annotated as Request or WebSocket.