### PR TITLE
Support Annotated types in OpenAPIHandler

### DIFF
--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -1,5 +1,6 @@
 import collections.abc as collections_abc
 import inspect
+import sys
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields, is_dataclass
@@ -9,6 +10,9 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 from typing import _GenericAlias as GenericAlias
 from typing import get_type_hints
 from uuid import UUID
+
+if sys.version_info >= (3, 9):  # pragma: no cover
+    from typing import _AnnotatedAlias as AnnotatedAlias
 
 from openapidocs.common import Format
 from openapidocs.v3 import (
@@ -458,6 +462,30 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
 
         return own_paths
 
+    def get_type_name_for_annotated(
+        self,
+        object_type: AnnotatedAlias,
+        context_type_args: Optional[Dict[Any, Type]] = None,
+    ) -> str:
+        """
+        This method returns a type name for an annotated type.
+        """
+        assert isinstance(
+            object_type, AnnotatedAlias
+        ), "This method requires an annotated type"
+        # Note: by default returns a string respectful of this requirement:
+        # $ref values must be RFC3986-compliant percent-encoded URIs
+        # Therefore, a generic that would be expressed in Python: Example[Foo, Bar]
+        # and C# or TypeScript Example<Foo, Bar>
+        # Becomes here represented as: ExampleOfFooAndBar
+        origin = get_origin(object_type)
+        annotations = object_type.__metadata__
+        annotations_repr = "And".join(
+            self.get_type_name(annotation, context_type_args)
+            for annotation in annotations
+        )
+        return f"{self.get_type_name(origin)}Of{annotations_repr}"
+
     def get_type_name_for_generic(
         self,
         object_type: GenericAlias,
@@ -484,6 +512,9 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
     ) -> str:
         if context_type_args and object_type in context_type_args:
             object_type = context_type_args.get(object_type)
+        if sys.version_info >= (3, 9):  # pragma: no cover
+            if isinstance(object_type, AnnotatedAlias):
+                return self.get_type_name_for_annotated(object_type, context_type_args)
         if isinstance(object_type, GenericAlias):
             return self.get_type_name_for_generic(object_type, context_type_args)
         if hasattr(object_type, "__name__"):
@@ -661,6 +692,12 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
         if schema:
             return schema
 
+        if sys.version_info >= (3, 9):  # pragma: no cover
+            if isinstance(object_type, AnnotatedAlias):
+                schema = self._try_get_schema_for_annotated(object_type, type_args)
+                if schema:
+                    return schema
+
         if isinstance(object_type, GenericAlias):
             schema = self._try_get_schema_for_generic(object_type, type_args)
             if schema:
@@ -731,6 +768,24 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
                 )
 
         return []
+
+    def _try_get_schema_for_annotated(
+        self, object_type: Type, context_type_args: Optional[Dict[Any, Type]] = None
+    ) -> Optional[Schema | Reference]:
+        annotations = [child for child in getattr(object_type, "__metadata__", [])]
+        if len(annotations) == 1:
+            return self.get_schema_by_type(annotations[0], context_type_args)
+        assert (
+            None not in annotations
+        ), "None is not a valid type for an annotated type with multiple annotations"
+        schema = Schema(
+            ValueType.OBJECT,
+            any_of=[
+                self.get_schema_by_type(annotation, context_type_args)
+                for annotation in annotations
+            ],
+        )
+        return self._handle_object_type_schema(object_type, context_type_args, schema)
 
     def _try_get_schema_for_generic(
         self, object_type: Type, context_type_args: Optional[Dict[Any, Type]] = None
@@ -1005,6 +1060,13 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
                 # responses[response_status_to_str(200)] = return_type
                 if data is None:
                     data = {}
+
+                if sys.version_info >= (3, 9):  # pragma: no cover
+                    if (
+                        isinstance(return_type, AnnotatedAlias)
+                        and return_type.__metadata__[0] is None
+                    ):
+                        return_type = None
 
                 if return_type is None:
                     # the user explicitly marked the request handler as returning None,

--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -464,7 +464,7 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
 
     def get_type_name_for_annotated(
         self,
-        object_type: AnnotatedAlias,
+        object_type: "AnnotatedAlias",
         context_type_args: Optional[Dict[Any, Type]] = None,
     ) -> str:
         """
@@ -771,7 +771,7 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
 
     def _try_get_schema_for_annotated(
         self, object_type: Type, context_type_args: Optional[Dict[Any, Type]] = None
-    ) -> Optional[Schema | Reference]:
+    ) -> Optional[Union[Schema, Reference]]:
         annotations = [child for child in getattr(object_type, "__metadata__", [])]
         if len(annotations) == 1:
             return self.get_schema_by_type(annotations[0], context_type_args)

--- a/tests/test_openapi_v3.py
+++ b/tests/test_openapi_v3.py
@@ -1,8 +1,12 @@
+import sys
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import IntEnum
 from typing import Generic, List, Optional, Sequence, TypeVar, Union
 from uuid import UUID
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
 
 import pytest
 from openapidocs.common import Format, Serializer
@@ -24,6 +28,7 @@ from pydantic import VERSION as PYDANTIC_LIB_VERSION
 from pydantic import BaseModel, HttpUrl
 from pydantic.types import NegativeFloat, PositiveInt, condecimal, confloat, conint
 
+from blacksheep.messages import Response
 from blacksheep.server.application import Application
 from blacksheep.server.bindings import FromForm
 from blacksheep.server.controllers import APIController
@@ -239,6 +244,35 @@ def get_cats_api() -> Application:
 
     @delete("/api/cats/{cat_id}")
     def delete_cat(cat_id: int) -> None:
+        ...
+
+    return app
+
+
+def get_cats_annotated_api() -> Application:
+    app = get_app()
+    get = app.router.get
+    post = app.router.post
+    delete = app.router.delete
+
+    @get("/api/cats")
+    def get_cats_annotated() -> Annotated[Response, PaginatedSet[Cat]]:
+        ...
+
+    @get("/api/cats_2")
+    def get_cats_annotated_2() -> Annotated[Response, PaginatedSet[Cat], List[Cat]]:
+        ...
+
+    @get("/api/cats/{cat_id}")
+    def get_cat_details_annotated(cat_id: int) -> Annotated[Response, CatDetails]:
+        ...
+
+    @post("/api/cats")
+    def create_cat_annotated(input: CreateCatInput) -> Annotated[Response, Cat]:
+        ...
+
+    @delete("/api/cats/{cat_id}")
+    def delete_cat_annotated(cat_id: int) -> Annotated[Response, None]:
         ...
 
     return app
@@ -1594,6 +1628,374 @@ components:
                 name:
                     type: string
                     nullable: false
+        CatOwner:
+            type: object
+            required:
+            - id
+            - first_name
+            - last_name
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                first_name:
+                    type: string
+                    nullable: false
+                last_name:
+                    type: string
+                    nullable: false
+        CatDetails:
+            type: object
+            required:
+            - id
+            - name
+            - owner
+            - friends
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                name:
+                    type: string
+                    nullable: false
+                owner:
+                    $ref: '#/components/schemas/CatOwner'
+                friends:
+                    type: array
+                    nullable: false
+                    items:
+                        type: integer
+                        format: int64
+                        nullable: false
+tags: []
+""".strip()
+    )
+
+
+@pytest.mark.asyncio
+async def test_cats_annotated_api(docs: OpenAPIHandler, serializer: Serializer):
+    if sys.version_info < (3, 9):
+        pytest.skip(
+            "Python 3.9+ required. Annotated types are not supported before 3.9"
+        )
+    app = get_cats_annotated_api()
+    docs.bind_app(app)
+    await app.start()
+
+    yaml = serializer.to_yaml(docs.generate_documentation(app))
+
+    assert (
+        yaml.strip()
+        == """
+openapi: 3.0.3
+info:
+    title: Example
+    version: 0.0.1
+paths:
+    /api/cats:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedSetOfCat'
+            operationId: get_cats_annotated
+        post:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Cat'
+            operationId: create_cat_annotated
+            parameters: []
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/CreateCatInput'
+                required: true
+    /api/cats_2:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ResponseOfPaginatedSetOfCatAndlistOfCat'
+            operationId: get_cats_annotated_2
+    /api/cats/{cat_id}:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CatDetails'
+            operationId: get_cat_details_annotated
+            parameters:
+            -   name: cat_id
+                in: path
+                schema:
+                    type: integer
+                    format: int64
+                    nullable: false
+                description: ''
+                required: true
+        delete:
+            responses:
+                '204':
+                    description: Success response
+            operationId: delete_cat_annotated
+            parameters:
+            -   name: cat_id
+                in: path
+                schema:
+                    type: integer
+                    format: int64
+                    nullable: false
+                description: ''
+                required: true
+components:
+    schemas:
+        Cat:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                name:
+                    type: string
+                    nullable: false
+        PaginatedSetOfCat:
+            type: object
+            required:
+            - items
+            - total
+            properties:
+                items:
+                    type: array
+                    nullable: false
+                    items:
+                        $ref: '#/components/schemas/Cat'
+                total:
+                    type: integer
+                    format: int64
+                    nullable: false
+        CreateCatInput:
+            type: object
+            required:
+            - name
+            properties:
+                name:
+                    type: string
+                    nullable: false
+        ResponseOfPaginatedSetOfCatAndlistOfCat:
+            type: object
+            anyOf:
+            -   $ref: '#/components/schemas/PaginatedSetOfCat'
+            -   type: array
+                nullable: false
+                items:
+                    $ref: '#/components/schemas/Cat'
+        CatOwner:
+            type: object
+            required:
+            - id
+            - first_name
+            - last_name
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                first_name:
+                    type: string
+                    nullable: false
+                last_name:
+                    type: string
+                    nullable: false
+        CatDetails:
+            type: object
+            required:
+            - id
+            - name
+            - owner
+            - friends
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                name:
+                    type: string
+                    nullable: false
+                owner:
+                    $ref: '#/components/schemas/CatOwner'
+                friends:
+                    type: array
+                    nullable: false
+                    items:
+                        type: integer
+                        format: int64
+                        nullable: false
+tags: []
+""".strip()
+    )
+
+
+@pytest.mark.asyncio
+async def test_cats_annotated_api_capital_operations_ids(
+    capitalize_operation_id_docs: CapitalizeOperationDocs,
+    serializer: Serializer,
+):
+    if sys.version_info < (3, 9):
+        pytest.skip(
+            "Python 3.9+ required. Annotated types are not supported before 3.9"
+        )
+
+    app = get_cats_annotated_api()
+    docs = capitalize_operation_id_docs
+
+    docs.bind_app(app)
+    await app.start()
+
+    yaml = serializer.to_yaml(docs.generate_documentation(app))
+
+    assert (
+        yaml.strip()
+        == """
+openapi: 3.0.3
+info:
+    title: Example
+    version: 0.0.1
+paths:
+    /api/cats:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PaginatedSetOfCat'
+            operationId: Get cats annotated
+        post:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Cat'
+            operationId: Create cat annotated
+            parameters: []
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/CreateCatInput'
+                required: true
+    /api/cats_2:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ResponseOfPaginatedSetOfCatAndlistOfCat'
+            operationId: Get cats annotated 2
+    /api/cats/{cat_id}:
+        get:
+            responses:
+                '200':
+                    description: Success response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CatDetails'
+            operationId: Get cat details annotated
+            parameters:
+            -   name: cat_id
+                in: path
+                schema:
+                    type: integer
+                    format: int64
+                    nullable: false
+                description: ''
+                required: true
+        delete:
+            responses:
+                '204':
+                    description: Success response
+            operationId: Delete cat annotated
+            parameters:
+            -   name: cat_id
+                in: path
+                schema:
+                    type: integer
+                    format: int64
+                    nullable: false
+                description: ''
+                required: true
+components:
+    schemas:
+        Cat:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                    nullable: false
+                name:
+                    type: string
+                    nullable: false
+        PaginatedSetOfCat:
+            type: object
+            required:
+            - items
+            - total
+            properties:
+                items:
+                    type: array
+                    nullable: false
+                    items:
+                        $ref: '#/components/schemas/Cat'
+                total:
+                    type: integer
+                    format: int64
+                    nullable: false
+        CreateCatInput:
+            type: object
+            required:
+            - name
+            properties:
+                name:
+                    type: string
+                    nullable: false
+        ResponseOfPaginatedSetOfCatAndlistOfCat:
+            type: object
+            anyOf:
+            -   $ref: '#/components/schemas/PaginatedSetOfCat'
+            -   type: array
+                nullable: false
+                items:
+                    $ref: '#/components/schemas/Cat'
         CatOwner:
             type: object
             required:


### PR DESCRIPTION
The idea is to support `Annotated` in building OpenAPI documentation and making type checkers happy as well.

I don't think this implementation is the right way to support such a feature. So, feel free to share any thoughts you have.

Example:

```python
class Cats(APIController):
    @get("/cats/{cat_id}")
    def get_cat_details_annotated(cat_id: int) -> Annotated[Response, CatDetails]:
        ...
        return self.json(
            data=asdict(
                CatDetails(**cat_details)
            )
        )

```