### PR TITLE
Update v3.py - Fix bug in _get_array_outer_type

### DIFF
--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -308,7 +308,7 @@ class PydanticModelTypeHandler(ObjectTypeHandler):
         except AttributeError:
             # Pydantic v2
             # Here we support only simple types
-            return List[field_info.annotation.__args__[0]]
+            return field_info.annotation
 
     def _get_fields_info(self, object_type):
         try:


### PR DESCRIPTION
Fix the error in L311
return List[field_info.annotation.__args__[0]]

The field_info.annotation returns an array, so __args__ is an invalid operation. This commit fixes that issue by returning the field_info.annotation object directly.