### PR TITLE
Update v3.py - Fix error in _get_array_outer_type

### DIFF
--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -308,7 +308,7 @@ class PydanticModelTypeHandler(ObjectTypeHandler):
         except AttributeError:
             # Pydantic v2
             # Here we support only simple types
-            return List[field_info.annotation.__args__[0]]
+            return field_info.annotation if type(field_info.annotation) is list else List[field_info.annotation.__args__[0]]
 
     def _get_fields_info(self, object_type):
         try:


### PR DESCRIPTION
The except clause of _get_array_outer_type can return field_info.annotation as a list, so the __args__ element is not valid. Check for this type and return the raw element.