### PR TITLE
accept to overwrite sent headers when using TestClient

### DIFF
--- a/blacksheep/testing/helpers.py
+++ b/blacksheep/testing/helpers.py
@@ -106,9 +106,12 @@ def get_example_scope(
             (b"connection", b"keep-alive"),
             (b"upgrade-insecure-requests", b"1"),
         ]
-        + ([tuple(header) for header in extra_headers] if extra_headers else [])
         + cookies_headers
     )
+
+    headers = dict(headers) # convert sequence of tuple into dict
+    headers.update(dict(extra_headers) if extra_headers else {}) # overwrite previously defined header if any
+    headers = list(headers.items()) # convert dict to sequence of tuple
 
     return {
         "type": scheme,


### PR DESCRIPTION
Hello,

Somehow related to #501 , there is a bug when testing if we specify a header already defined in the helper.

```python
        response = await test_client.get("/test", headers={"accept": "application/json"})
```

**Bug:**

The accept header is already set in the helper and the specified value is not send.

**Expected:**

The accept header sent is the one specified in the test call
