### PR TITLE
Fix/365 - improve support for Pydantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix [#365](https://github.com/Neoteroi/BlackSheep/issues/365), adding support for
   Pydantic's `@validate_arguments` and other wrappers applied to functions before they
-  are decorated as request handlers.
+  are decorated as request handlers. Contribution by @aldem, who provided the resolution
+  in the issue.
 
 ## [2.2.0] - 2025-04-28 🎉
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.1] - 2025-??-??
 
 - Fix [#365](https://github.com/Neoteroi/BlackSheep/issues/365), adding support for
-  Pydantic's `@validate_arguments` and other wrappers applied to functions before they
-  are decorated as request handlers. Contribution by @aldem, who provided the resolution
-  in the issue.
+  Pydantic's `@validate_call` and `@validate_arguments` and other wrappers applied to
+  functions before they are configured as request handlers.
+  Contribution by @aldem, who reported the issue and provided the solution.
+- To better support `@validate_call`, automatically configures a default
+  exception handler for `pydantic.ValidationError` when Pydantic is installed.
 
 ## [2.2.0] - 2025-04-28 🎉
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2025-??-??
+
+- Fix [#365](https://github.com/Neoteroi/BlackSheep/issues/365), adding support for
+  Pydantic's `@validate_arguments` and other wrappers applied to functions before they
+  are decorated as request handlers.
+
 ## [2.2.0] - 2025-04-28 🎉
 
 - Fix [#533](https://github.com/Neoteroi/BlackSheep/issues/533). **A feature

--- a/blacksheep/server/normalization.py
+++ b/blacksheep/server/normalization.py
@@ -663,8 +663,7 @@ def _get_async_wrapper_for_output(
     @wraps(method)
     async def handler(request: Request) -> Response:
         response = await method(request)
-        # Handle consequences of @validate_arguments decorator
-        # applied to async code
+        # Handle consequences of an async decorator
         if inspect.isawaitable(response):
             response = await response
         return ensure_response(response)

--- a/blacksheep/server/normalization.py
+++ b/blacksheep/server/normalization.py
@@ -695,7 +695,7 @@ def get_streaming_response_class(object_type):
 
 
 def _is_wrapped_function(func):
-    return hasattr(func, '__wrapped__')
+    return hasattr(func, "__wrapped__")
 
 
 def normalize_handler(

--- a/blacksheep/server/normalization.py
+++ b/blacksheep/server/normalization.py
@@ -662,7 +662,12 @@ def _get_async_wrapper_for_output(
 ) -> Callable[[Request], Awaitable[Response]]:
     @wraps(method)
     async def handler(request: Request) -> Response:
-        return ensure_response(await method(request))
+        response = await method(request)
+        # Handle consequences of @validate_arguments decorator
+        # applied to async code
+        if inspect.isawaitable(response):
+            response = await response
+        return ensure_response(response)
 
     return handler
 
@@ -687,6 +692,10 @@ def get_streaming_response_class(object_type):
         return _STREAMING_TYPES[object_type]
     except KeyError:
         return None
+
+
+def _is_wrapped_function(func):
+    return hasattr(func, '__wrapped__')
 
 
 def normalize_handler(
@@ -747,6 +756,9 @@ def normalize_handler(
             # this scenario enables a more accurate automatic generation of
             # OpenAPI Documentation, for responses
             setattr(route.handler, "return_type", return_type)
+        normalized = _get_async_wrapper_for_output(normalized)
+
+    if _is_wrapped_function(normalized):
         normalized = _get_async_wrapper_for_output(normalized)
 
     if normalized is not method:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -4051,6 +4051,8 @@ async def test_application_sub_router_normalization():
 
 
 async def test_pydantic_validate_call_scenario():
+    from pydantic import VERSION as PYDANTIC_LIB_VERSION
+
     app = FakeApplication(show_error_details=True, router=Router())
     get = app.router.get
 
@@ -4085,4 +4087,6 @@ async def test_pydantic_validate_call_scenario():
             response = app.response
             assert response is not None
             assert response.status == status
-            assert response_text in (await response.text())
+
+            if int(PYDANTIC_LIB_VERSION[0]) > 1:
+                assert response_text in (await response.text())

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -11,7 +11,7 @@ from uuid import UUID, uuid4
 import pytest
 from guardpost import AuthenticationHandler, Identity, User
 from openapidocs.v3 import Info
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError, validate_call
 from rodi import Container, inject
 
 from blacksheep import HTTPException, JSONContent, Request, Response, TextContent
@@ -4041,3 +4041,40 @@ async def test_application_sub_router_normalization():
     response = app.response
     assert response is not None
     assert response.status == 200
+
+
+async def test_pydantic_validate_args_scenario():
+    app = FakeApplication(show_error_details=True, router=Router())
+    get = app.router.get
+
+    @get("/test1")
+    @validate_call
+    async def something(i: Annotated[int, Field(ge=1, le=10)] = 1):
+        return text(f"i={i}")
+
+    @get("/test2")
+    @validate_call
+    async def something_with_response_annotation(
+        i: Annotated[int, Field(ge=1, le=10)] = 1,
+    ) -> Response:
+        return text(f"i={i}")
+
+    await app.start()
+
+    expectations = [
+        ("", 200, "i=1"),
+        ("i=5", 200, "i=5"),
+        ("i=20", 400, "Input should be less than or equal to 10"),
+    ]
+
+    for endpoint in ["/test1", "/test2"]:
+        for query, status, response_text in expectations:
+            await app(
+                get_example_scope("GET", endpoint, query=query),
+                MockReceive(),
+                MockSend(),
+            )
+            response = app.response
+            assert response is not None
+            assert response.status == status
+            assert response_text in (await response.text())

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from functools import wraps
-from typing import Optional
+from typing import Annotated, Optional
 
 import pytest
 from guardpost import AuthenticationHandler, User
+from pydantic import Field
 from rodi import inject
 
 from blacksheep import Request, Response
@@ -22,6 +23,13 @@ from blacksheep.testing.helpers import get_example_scope
 from blacksheep.testing.messages import MockReceive, MockSend
 from blacksheep.utils import ensure_str
 from tests.test_files_serving import get_file_path
+
+try:
+    # v2
+    from pydantic import validate_call
+except ImportError:
+    # v1
+    from pydantic import validate_arguments as validate_call
 
 
 # NB: the following is an example of generic decorator (defined using *args and **kwargs)
@@ -973,3 +981,40 @@ async def test_controller_filters(app):
     assert app.response.status == 200
     data = await app.response.text()
     assert data == "Hello World"
+
+
+async def test_controller_pydantic_validate_call_scenario(app):
+    app.controllers_router = RoutesRegistry()
+    get = app.controllers_router.get
+
+    class Home(Controller):
+        @get("/test1")
+        @validate_call
+        async def test1(self, i: Annotated[int, Field(ge=1, le=10)] = 1) -> str:
+            return f"i={i}"
+
+        @get("/test2")
+        @validate_call
+        async def test2(self, i: Annotated[int, Field(ge=1, le=10)] = 1) -> Response:
+            return self.text(f"i={i}")
+
+    await app.start()
+
+    expectations = [
+        ("", 200, "i=1"),
+        ("i=5", 200, "i=5"),
+        ("i=-3", 400, "Input should be greater than or equal to 1"),
+        ("i=20", 400, "Input should be less than or equal to 10"),
+    ]
+
+    for endpoint in ["/test1", "/test2"]:
+        for query, status, response_text in expectations:
+            await app(
+                get_example_scope("GET", endpoint, query=query),
+                MockReceive(),
+                MockSend(),
+            )
+            response = app.response
+            assert response is not None
+            assert response.status == status
+            assert response_text in (await response.text())

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -984,6 +984,8 @@ async def test_controller_filters(app):
 
 
 async def test_controller_pydantic_validate_call_scenario(app):
+    from pydantic import VERSION as PYDANTIC_LIB_VERSION
+
     app.controllers_router = RoutesRegistry()
     get = app.controllers_router.get
 
@@ -1017,4 +1019,5 @@ async def test_controller_pydantic_validate_call_scenario(app):
             response = app.response
             assert response is not None
             assert response.status == status
-            assert response_text in (await response.text())
+            if int(PYDANTIC_LIB_VERSION[0]) > 1:
+                assert response_text in (await response.text())

--- a/tests/utils/application.py
+++ b/tests/utils/application.py
@@ -8,7 +8,7 @@ class FakeApplication(Application):
     """Application class used for testing."""
 
     def __init__(self, *args, **kwargs):
-        super().__init__(show_error_details=False, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.request: Optional[Request] = None
         self.response: Optional[Response] = None
 


### PR DESCRIPTION
- Fix [#365](https://github.com/Neoteroi/BlackSheep/issues/365), adding support for
  Pydantic's `@validate_call` and `@validate_arguments` and other wrappers applied to
  functions before they are configured as request handlers.
  Contribution by @aldem, who reported the issue and provided the solution.
- To better support `@validate_call`, automatically configures a default
  exception handler for `pydantic.ValidationError` when Pydantic is installed.