### PR TITLE
Fix #550

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Contribution by @aldem, who reported the issue and provided the solution.
 - To better support `@validate_call`, automatically configures a default
   exception handler for `pydantic.ValidationError` when Pydantic is installed.
+- Fix [#550](https://github.com/Neoteroi/BlackSheep/issues/550). Ensure that
+  all generated `$ref` values contain only [allowed characters](https://swagger.io/docs/specification/v3_0/using-ref/).
 
 ## [2.2.0] - 2025-04-28 🎉
 

--- a/blacksheep/server/openapi/v3.py
+++ b/blacksheep/server/openapi/v3.py
@@ -447,13 +447,36 @@ class OpenAPIHandler(APIDocsHandler[OpenAPI]):
 
         return own_paths
 
+    def get_type_name_for_generic(
+        self,
+        object_type: GenericAlias,
+        context_type_args: Optional[Dict[Any, Type]] = None,
+    ) -> str:
+        """
+        This method returns a type name for a generic type.
+        """
+        assert isinstance(object_type, GenericAlias), "This method requires a generic"
+        # Note: by default returns a string respectful of this requirement:
+        # $ref values must be RFC3986-compliant percent-encoded URIs
+        # Therefore, a generic that would be expressed in Python: Example[Foo, Bar]
+        # and C# or TypeScript Example<Foo, Bar>
+        # Becomes here represented as: ExampleOfFooAndBar
+        origin = get_origin(object_type)
+        args = object_type.__args__
+        args_repr = "And".join(
+            self.get_type_name(arg, context_type_args) for arg in args
+        )
+        return f"{self.get_type_name(origin)}Of{args_repr}"
+
     def get_type_name(
         self, object_type, context_type_args: Optional[Dict[Any, Type]] = None
     ) -> str:
         if context_type_args and object_type in context_type_args:
             object_type = context_type_args.get(object_type)
+        if isinstance(object_type, GenericAlias):
+            return self.get_type_name_for_generic(object_type, context_type_args)
         if hasattr(object_type, "__name__"):
-            return object_type.__name__  # type: ignore
+            return object_type.__name__
         if object_type is Union:
             # Python 3.9 and 3.8 would fall here, Union type has a "_name" property but
             # no "__name__"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from uuid import UUID, uuid4
 import pytest
 from guardpost import AuthenticationHandler, Identity, User
 from openapidocs.v3 import Info
+from pydantic import VERSION as PYDANTIC_LIB_VERSION
 from pydantic import BaseModel, Field, ValidationError
 from rodi import Container, inject
 
@@ -4051,8 +4053,6 @@ async def test_application_sub_router_normalization():
 
 
 async def test_pydantic_validate_call_scenario():
-    from pydantic import VERSION as PYDANTIC_LIB_VERSION
-
     app = FakeApplication(show_error_details=True, router=Router())
     get = app.router.get
 
@@ -4090,3 +4090,42 @@ async def test_pydantic_validate_call_scenario():
 
             if int(PYDANTIC_LIB_VERSION[0]) > 1:
                 assert response_text in (await response.text())
+
+
+@pytest.mark.skipif(
+    int(PYDANTIC_LIB_VERSION[0]) < 2, reason="Run this test only with Pydantic v2"
+)
+async def test_refs_characters_handling():
+    app = FakeApplication(show_error_details=True, router=Router())
+    get = app.router.get
+
+    class Response[DataT](BaseModel):
+        data: DataT
+
+    class Cat(BaseModel):
+        id: int
+        name: str
+        creation_time: datetime
+
+    docs = OpenAPIHandler(info=Info(title="Example API", version="0.0.1"))
+    docs.bind_app(app)
+
+    @get("/cat")
+    def generic_example() -> Response[Cat]: ...
+
+    @get("/cats")
+    def generic_list_example() -> list[Response[Cat]]: ...
+
+    await app.start()
+
+    json_docs = docs._json_docs.decode("utf8")
+    yaml_docs = docs._yaml_docs.decode("utf8")
+    spec = json.loads(json_docs)
+
+    # "$ref": "#/components/schemas/Cat"
+    for key in spec["components"]["schemas"].keys():
+        assert re.match(
+            "^[a-zA-Z0-9-_.]+$", key
+        ), "$ref values must match /^[a-zA-Z0-9-_.]+$/"
+        assert f'"$ref": "#/components/schemas/{key}"' in json_docs
+        assert f"$ref: '#/components/schemas/{key}'" in yaml_docs

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -6,7 +6,7 @@ from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
 from datetime import date, datetime
 from functools import wraps
-from typing import Annotated, Any, Dict, List, Optional, TypeVar
+from typing import Annotated, Any, Dict, Generic, List, Optional, TypeVar
 from uuid import UUID, uuid4
 
 import pytest
@@ -4099,7 +4099,15 @@ async def test_refs_characters_handling():
     app = FakeApplication(show_error_details=True, router=Router())
     get = app.router.get
 
-    class Response[DataT](BaseModel):
+    # TODO: when support for Python < 3.12 is dropped,
+    # the following can be rewritten without TypeVar, like:
+    #
+    # class Response[DataT](BaseModel):
+    #
+
+    DataT = TypeVar("DataT")
+
+    class Response(BaseModel, Generic[DataT]):
         data: DataT
 
     class Cat(BaseModel):

--- a/tests/test_openapi_v3.py
+++ b/tests/test_openapi_v3.py
@@ -35,6 +35,7 @@ from blacksheep.server.bindings import FromForm
 from blacksheep.server.controllers import APIController
 from blacksheep.server.openapi.common import (
     ContentInfo,
+    DefaultSerializer,
     EndpointDocs,
     OpenAPIEndpointException,
     ResponseInfo,
@@ -3744,3 +3745,17 @@ components:
 
     for fragment in expected_fragments:
         assert fragment.strip() in yaml
+
+
+@pytest.mark.parametrize(
+    "name,result",
+    [
+        ("Example[Cat]", "ExampleOfCat"),
+        ("Union[A, B, C]", "UnionOfAAndBAndC"),
+        ("List[Union[A, B, C]]", "ListOfUnionOfAAndBAndC"),
+        ("Dict[str, int]", "DictOfstrAndint"),
+    ],
+)
+def test_default_serializer_sanitize_name(name, result):
+    serializer = DefaultSerializer()
+    assert serializer.get_type_name_for_generic(name) == result


### PR DESCRIPTION
Ensure that all generated `$ref` values for the OpenAPI documentation contain only [allowed characters](https://swagger.io/docs/specification/v3_0/using-ref/).