### PR TITLE
v2.3.1 🐎

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.1a1] - 2025-05-20 :racehorse:
-
-> [!NOTE]
-> This is an alpha release to test published wheels before publishing a normal
-> release.
+## [2.3.1] - 2025-05-20 :racehorse:
 
 - Add support for [`PyPy`](https://pypy.org/), adding a pure-Python fallback
   for all `Cython` modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for all `Cython` modules.
 - Fix [#539](https://github.com/Neoteroi/BlackSheep/issues/539). Make
   `httptools` an optional dependency, to support [`PyPy`](https://pypy.org/).
+- Modify `url.pyx` to remove the dependency on `httptools`.
 - Modify the HTTP Client implementation in BlackSheep to
   not be tightly coupled with `httptools` for the response parsing logic, and
   include built-in support for `h11`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ using one of the supported templates.
 The CLI includes a help, and supports custom templates, using the
 same sources supported by `Cookiecutter`.
 
+## Dependencies
+
+Before version `2.3.1`, BlackSheep only supported running with `CPython` and
+always depended on `httptools`. Starting with version `2.3.1`, the framework
+supports running on [`PyPy`](https://pypy.org/) and makes `httptools` an
+optional dependency.
+
+For slightly better performance in `URL` parsing when running on `CPython`,
+it is recommended to install `httptools`.
+
+> [!TIP]
+>
+> The best performance can be achieved using `PyPy` and
+> [`Socketify`](https://docs.socketify.dev/cli.html) (see
+> [#539](https://github.com/Neoteroi/BlackSheep/issues/539) for more information).
+
 ## Getting started with the documentation
 
 The documentation offers getting started tutorials:
@@ -167,9 +183,11 @@ feature that provides a consistent and clean way to use dependencies in request
 handlers.
 
 ## Generation of OpenAPI Documentation
+
 [Generation of OpenAPI Documentation](https://www.neoteroi.dev/blacksheep/openapi/).
 
 ## Strategies to handle authentication and authorization
+
 BlackSheep implements strategies to handle authentication and authorization.
 These features are documented here:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ same sources supported by `Cookiecutter`.
 Before version `2.3.1`, BlackSheep only supported running with `CPython` and
 always depended on `httptools`. Starting with version `2.3.1`, the framework
 supports running on [`PyPy`](https://pypy.org/) and makes `httptools` an
-optional dependency.
+optional dependency. The BlackSheep HTTP Client requires either `httptools`
+(for CPython) or `h11` (for PyPy).
 
 For slightly better performance in `URL` parsing when running on `CPython`,
 it is recommended to install `httptools`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ classifiers. The current list is:
 
 [![versions](https://img.shields.io/pypi/pyversions/blacksheep.svg)](https://github.com/robertoprevato/blacksheep)
 
+> [!TIP]
+>
+> Starting from version `2.3.1`, BlackSheep supports [PyPy](https://pypy.org/), too (`PyPy 3.11`).
+> Previous versions of the framework supported only [CPython](https://github.com/python/cpython).
 
 BlackSheep belongs to the category of
 [ASGI](https://asgi.readthedocs.io/en/latest/) web frameworks, so it requires
@@ -98,6 +102,7 @@ To run for production, refer to the documentation of the chosen ASGI server
 (i.e. for [uvicorn](https://www.uvicorn.org/#running-with-gunicorn)).
 
 ## Automatic bindings and dependency injection
+
 BlackSheep supports automatic binding of values for request handlers, by type
 annotation or by conventions. See [more
 here](https://www.neoteroi.dev/blacksheep/requests/).
@@ -192,7 +197,7 @@ async def only_for_authenticated_users():
     ...
 ```
 
-Since version `1.2.1`, BlackSheep implements:
+BlackSheep provides:
 
 * [Built-in support for OpenID Connect authentication](https://www.neoteroi.dev/blacksheep/authentication/#oidc)
 * [Built-in support for JWT Bearer authentication](https://www.neoteroi.dev/blacksheep/authentication/#jwt-bearer)
@@ -243,7 +248,7 @@ for more details and examples.
 * [Strategy to handle CORS settings](https://www.neoteroi.dev/blacksheep/cors/)
 * [Sessions](https://www.neoteroi.dev/blacksheep/sessions/)
 * Support for automatic binding of `dataclasses` and
-  [`pydantic`](https://pydantic-docs.helpmanual.io) models to handle the
+  [`Pydantic`](https://pydantic-docs.helpmanual.io) models to handle the
   request body payload expected by request handlers
 * [`TestClient` class to simplify testing of applications](https://www.neoteroi.dev/blacksheep/testing/)
 * [Anti Forgery validation](https://www.neoteroi.dev/blacksheep/anti-request-forgery) to protect against Cross-Site Request Forgery (XSRF/CSRF) attacks
@@ -269,18 +274,30 @@ async def client_example():
 asyncio.run(client_example())
 ```
 
+> [!IMPORTANT]
+>
+> Starting from version `2.3.1`, BlackSheep supports [PyPy](https://pypy.org/),
+> too (`PyPy 3.11`). For this reason, using the client requires an additional
+> dependency: `httptools` if using CPython, `h11` if using `PyPy`. This affects
+> only the `blacksheep.client` namespace.
+
 ## Supported platforms and runtimes
-* Python: all versions included in the build matrix
-* Ubuntu
-* Windows 10
-* macOS
+
+* Python: all versions included in the [build matrix](.github/workflows/main.yml).
+* CPython and PyPy.
+* Ubuntu.
+* Windows 10.
+* macOS.
 
 ## Documentation
+
 Please refer to the [documentation website](https://www.neoteroi.dev/blacksheep/).
 
 ## Communication
+
 [BlackSheep community in Gitter](https://gitter.im/Neoteroi/BlackSheep).
 
 ## Branches
+
 The _main_ branch contains the currently developed version, which is version 2. The _v1_ branch contains version 1 of the web framework, for bugs fixes
 and maintenance.

--- a/blacksheep/__init__.py
+++ b/blacksheep/__init__.py
@@ -4,7 +4,7 @@ used types to reduce the verbosity of the imports statements.
 """
 
 __author__ = "Roberto Prevato <roberto.prevato@gmail.com>"
-__version__ = "2.3.1a1"
+__version__ = "2.3.1"
 
 from .contents import Content as Content
 from .contents import FormContent as FormContent

--- a/blacksheep/client/connection.py
+++ b/blacksheep/client/connection.py
@@ -327,6 +327,8 @@ class ClientConnection(asyncio.Protocol):
             if self.transport:
                 self.transport.close()
 
+            self.parser = None
+
     def data_received(self, data: bytes) -> None:
         try:
             self.parser.feed_data(data)

--- a/blacksheep/client/parser.py
+++ b/blacksheep/client/parser.py
@@ -66,11 +66,12 @@ if h11 is not None:
 
 
 def get_default_parser(client_connection):
-    if httptools is not None:
-        return HTTPToolsResponseParser(client_connection)
 
     if h11 is not None:
         return H11ResponseParser(client_connection)
+
+    if httptools is not None:
+        return HTTPToolsResponseParser(client_connection)
 
     raise RuntimeError(
         "Missing Python dependencies to provide a default HTTP Response parser. "

--- a/blacksheep/url.pyx
+++ b/blacksheep/url.pyx
@@ -1,4 +1,11 @@
-from urllib.parse import urlparse
+# Try to import httptools, else fallback to urllib.parse
+try:
+    import httptools
+    from httptools.parser import errors
+    _has_httptools = True
+except ImportError:
+    from urllib.parse import urlparse
+    _has_httptools = False
 
 
 cdef class InvalidURL(Exception):
@@ -14,25 +21,44 @@ cdef inline valid_schema(bytes schema):
 cdef class URL:
 
     def __init__(self, bytes value):
-        if not value:
-            raise InvalidURL("Input empty or null.")
         cdef bytes schema
         cdef object port
+        if not value:
+            raise InvalidURL("Input empty or null.")
         try:
-            # urllib.parse.urlparse expects str, not bytes
-            parsed = urlparse(value.decode())
+            # if the value starts with a dot, prepend a slash;
+            # urllib.parse urlparse handles those, while httptools raises
+            # an exception
+            if value and value[0] == 46:
+                value = b"/" + value
+            if _has_httptools:
+                parsed = httptools.parse_url(value)
+                schema = parsed.schema
+                valid_schema(schema)
+                self.value = value or b''
+                self.schema = schema
+                self.host = parsed.host
+                self.port = parsed.port or 0
+                self.path = parsed.path
+                self.query = parsed.query
+                self.fragment = parsed.fragment
+                self.is_absolute = parsed.schema is not None
+            else:
+                # urllib.parse.urlparse expects str, not bytes
+                parsed = urlparse(value.decode())
+                schema = parsed.scheme.encode() if parsed.scheme else b''
+                valid_schema(schema)
+                self.value = value or b''
+                self.schema = schema
+                self.host = parsed.hostname.encode() if parsed.hostname else b''
+                self.port = parsed.port or 0
+                self.path = parsed.path.encode() if parsed.path else b''
+                self.query = parsed.query.encode() if parsed.query else b''
+                self.fragment = parsed.fragment.encode() if parsed.fragment else b''
+                self.is_absolute = bool(parsed.scheme)
         except Exception as exc:
+            # Handle both httptools and urllib.parse exceptions
             raise InvalidURL(f'The value cannot be parsed as URL ({value.decode()}): {exc}')
-        schema = parsed.scheme.encode() if parsed.scheme else None
-        valid_schema(schema)
-        self.value = value or b""
-        self.schema = schema
-        self.host = parsed.hostname.encode() if parsed.hostname else None
-        self.port = parsed.port or 0
-        self.path = parsed.path.encode() or b""
-        self.query = parsed.query.encode() if parsed.query else None
-        self.fragment = parsed.fragment.encode() if parsed.fragment else None
-        self.is_absolute = bool(schema)
 
     def __repr__(self):
         return f'<URL {self.value}>'


### PR DESCRIPTION
- Add support for [`PyPy`](https://pypy.org/), adding a pure-Python fallback
  for all `Cython` modules.
- Fix [#539](https://github.com/Neoteroi/BlackSheep/issues/539). Make
  `httptools` an optional dependency, to support [`PyPy`](https://pypy.org/).
- Modify `url.pyx` to remove the dependency on `httptools`.
- Modify the HTTP Client implementation in BlackSheep to
  not be tightly coupled with `httptools` for the response parsing logic, and
  include built-in support for `h11`.
- **MINOR BREAKING CHANGE**. Since `httptools` is not installed by default, the
  BlackSheep **client** requires either `httptools` or `h11` to be installed, as it
  does not implement its own parsing logic for HTTP responses. This affects
  only the HTTP client.
- Upgrade dependencies (see `pyproject.toml` for more information).
- Include a pure-Python wheel in the distribution package, and run tests
  with **PyPy 3.11**.
- Fix [#559](https://github.com/Neoteroi/BlackSheep/issues/559), which is a
  performance regression introduced in `2.3.0`. Remove support for Pydantic v1
  `validate_arguments` decorator (added in 2.3.0), which caused the regression.
  Pydantic's v2 `validate_call` supports async and does not require specific code.