### PR TITLE
Fix: preserve annotations and kwdefaults in clonefunc for controller inheritance

### DIFF
--- a/blacksheep/utils/meta.py
+++ b/blacksheep/utils/meta.py
@@ -33,7 +33,7 @@ def import_child_modules(root_path: Path):
 
 def clonefunc(func):
     """
-    Clone a function, preserving its name and docstring.
+    Clone a function, preserving its name, docstring, annotations and kwdefaults.
     """
     new_func = func.__class__(
         func.__code__,
@@ -44,6 +44,9 @@ def clonefunc(func):
     )
     new_func.__doc__ = func.__doc__
     new_func.__dict__ = copy.deepcopy(func.__dict__)
+    new_func.__annotations__ = copy.deepcopy(func.__annotations__)
+    if func.__kwdefaults__:
+        new_func.__kwdefaults__ = copy.deepcopy(func.__kwdefaults__)
     return new_func
 
 


### PR DESCRIPTION
# Inherited controller handlers lose `__annotations__` and `__kwdefaults__` when cloned

## Overview

This pull request fixes an issue in BlackSheep where **inherited controller handlers** lose argument type annotations and keyword-only defaults. For example, you can't have `POST` handlers that accept a typed request body and declare a return type (e.g., a Pydantic model).

---

## Context

BlackSheep supports **controller inheritance**, and the documentation includes an example with abstract base controllers:

```python
from blacksheep import Application
from blacksheep.server.controllers import Controller, abstract, get

app = Application()

@abstract()
class BaseController(Controller):
    @get("/hello-world")
    def index(self):
        # Note: the route /hello-world itself will not be registered in the
        # router, because this class is decorated with @abstract()
        return self.text(f"Hello, World! {self.__class__.__name__}")


class ControllerOne(BaseController):
    @classmethod
    def route(cls) -> str:
        return "/one"

    # /one/hello-world
```

In this example, the handlers do not have arguments or return types.

When controller handlers **do have arguments or return type annotations**, inherited handlers were previously losing this information.

---

## Fix

This pull request updates `clonefunc` to **preserve annotations and keyword defaults**, ensuring that inherited handlers retain argument type hints and keyword-only defaults.

The updated `clonefunc` copies:

- `__annotations__` → preserves argument and return type hints  
- `__kwdefaults__` → preserves keyword-only argument defaults

```python
def clonefunc(func):
    """
    Clone a function, preserving name, docstring, annotations, kwdefaults.
    """
    import copy

    new_func = func.__class__(
        func.__code__,
        func.__globals__,
        func.__name__,
        func.__defaults__,
        func.__closure__,
    )
    new_func.__doc__ = func.__doc__
    new_func.__dict__ = copy.deepcopy(func.__dict__)
    new_func.__annotations__ = copy.deepcopy(func.__annotations__)
    if getattr(func, "__kwdefaults__", None):
        new_func.__kwdefaults__ = copy.deepcopy(func.__kwdefaults__)
    return new_func
```

---

## Benefits

- Inherited **controller handlers** now **keep argument types and return type hints**.  Enables handlers (for example, POST methods) to accept typed request bodies and return Pydantic models — so generated OpenAPI schemas, request validation, and response serialization work correctly for inherited handlers. 
---

## Example

After the fix, a handler with arguments and return type works as expected:

```python
class GreetController(BaseController):
    @get("/greet")
    def greet(self, name: str, greeting: str = "Hello") -> str:
        return f"{greeting}, {name}!"
```
```python
class HelloWorldDTO(BaseModel):
    username: str


@abstract()
class BaseController(Controller):
    @post("/api/hello-world")
    def index(self, body: HelloWorldDTO):
        ...


class ControllerOne(BaseController):
    ...
```

- The `name: str` argument type and `-> str` return type are preserved in the inherited handler.  
- The keyword default `greeting: str = "Hello"` is preserved via `__kwdefaults__`.  
- OpenAPI documentation now shows the correct parameter type and return type.

---

## Backwards compatibility & notes
- This change is additive: it preserves additional metadata on cloned functions and should not break existing behavior.  
- If other modules clone functions differently, consider centralizing cloning logic to avoid duplication. But I can't see other models that are using this functionality.

