### PR TITLE
Fix #643: preserve user-defined handlers for authorization exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   crashed with `AttributeError` when a handler returned `AsyncIterable[ServerSentEvent]`
   (or any `collections.abc` async-iterable generic). `_try_get_schema_for_generic` now
   skips types whose origin has no `__parameters__`.
+- Fix [#643](https://github.com/Neoteroi/BlackSheep/issues/643): `use_authorization()`
+  no longer overrides exception handlers that the user has already registered for
+  `UnauthorizedError`, `ForbiddenError`, `AuthenticateChallenge`, or
+  `RateLimitExceededError`. Framework defaults are now installed via `setdefault`
+  so user-defined handlers win regardless of registration order.
 
 ## [2.6.2] - 2026-02-25 :gift:
 

--- a/blacksheep/server/application.py
+++ b/blacksheep/server/application.py
@@ -528,14 +528,18 @@ class Application(BaseApplication):
             strategy.add(Policy("authenticated", AuthenticatedRequirement()))
 
         self._authorization_strategy = strategy
-        self.exceptions_handlers.update(
-            {  # type: ignore
-                AuthenticateChallenge: handle_authentication_challenge,
-                UnauthorizedError: handle_unauthorized,
-                ForbiddenError: handle_forbidden,
-                RateLimitExceededError: handle_rate_limited_auth,
-            }
-        )
+        # Install framework defaults for authorization exceptions, but only for
+        # types that the user has not already registered a handler for. This
+        # lets users register their own handlers either before or after the
+        # call to ``use_authorization()`` and keep them in effect — see #643.
+        framework_defaults = {  # type: ignore
+            AuthenticateChallenge: handle_authentication_challenge,
+            UnauthorizedError: handle_unauthorized,
+            ForbiddenError: handle_forbidden,
+            RateLimitExceededError: handle_rate_limited_auth,
+        }
+        for exception_type, default_handler in framework_defaults.items():
+            self.exceptions_handlers.setdefault(exception_type, default_handler)
 
         self.middlewares.append(
             get_authorization_middleware(strategy), MiddlewareCategory.AUTHZ, 0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,17 +5,20 @@ import jwt
 import pytest
 from essentials.secrets import Secret
 from guardpost import AuthorizationContext, Identity, Policy, UnauthorizedError
+from guardpost.authorization import ForbiddenError
 from guardpost.common import AuthenticatedRequirement
 from guardpost.jwks import JWKS, InMemoryKeysProvider, KeysProvider
 from guardpost.jwts import SymmetricJWTValidator
 from pytest import raises
 from rodi import Container
 
+from blacksheep import Response, TextContent
 from blacksheep.messages import Request
 from blacksheep.server.application import Application
 from blacksheep.server.authentication import (
     AuthenticateChallenge,
     AuthenticationHandler,
+    handle_authentication_challenge,
 )
 from blacksheep.server.authentication.jwt import JWTBearerAuthentication
 from blacksheep.server.authorization import (
@@ -24,6 +27,8 @@ from blacksheep.server.authorization import (
     allow_anonymous,
     auth,
     get_www_authenticated_header_from_generic_unauthorized_error,
+    handle_forbidden,
+    handle_unauthorized,
 )
 from blacksheep.server.di import di_scope_middleware, register_http_context
 from blacksheep.server.resources import get_resource_file_path
@@ -1135,6 +1140,121 @@ async def test_jwt_openid_tokens_handler_authenticate_with_refresh_token(
     assert identity.is_authenticated() is True
     assert identity["sub"] == "user456"
     assert identity.refresh_token == "my-refresh-token"  # type: ignore[attr-defined]
+
+
+# endregion
+
+
+# region user-defined exception handlers vs framework defaults — issue #643
+
+
+async def test_user_unauthorized_handler_wins_when_registered_before_use_authorization(
+    app,
+):
+    """Regression for #643.
+
+    Registering an exception handler for ``UnauthorizedError`` BEFORE
+    ``use_authorization()`` must not be silently overridden by the framework
+    defaults installed inside ``use_authorization()``.
+    """
+
+    @app.exception_handler(UnauthorizedError)
+    async def custom_unauthorized(self, request, exc):
+        return Response(401, content=TextContent("Custom unauthorized page"))
+
+    app.use_authentication().add(MockNotAuthHandler())
+    app.use_authorization().default_policy += AuthenticatedRequirement()
+
+    @auth()
+    @app.router.get("/")
+    async def home():
+        return None
+
+    await app(get_example_scope("GET", "/"), MockReceive(), MockSend())
+
+    assert app.response is not None
+    assert app.response.status == 401
+    body = await app.response.text()
+    assert body == "Custom unauthorized page"
+
+
+async def test_user_forbidden_handler_wins_when_registered_before_use_authorization(
+    app,
+):
+    """Same as above but for ``ForbiddenError`` (HTTP 403)."""
+
+    @app.exception_handler(ForbiddenError)
+    async def custom_forbidden(self, request, exc):
+        return Response(403, content=TextContent("Custom forbidden page"))
+
+    admin = Identity({"id": "001", "role": "user"}, "JWT")
+    app.use_authentication().add(MockAuthHandler(admin))
+    app.use_authorization().add(AdminsPolicy())
+
+    @auth("admin")
+    @app.router.get("/")
+    async def home():
+        return None
+
+    await app(get_example_scope("GET", "/"), MockReceive(), MockSend())
+
+    assert app.response is not None
+    assert app.response.status == 403
+    body = await app.response.text()
+    assert body == "Custom forbidden page"
+
+
+async def test_user_unauthorized_handler_wins_when_registered_after_use_authorization(
+    app,
+):
+    """Sanity: registering AFTER ``use_authorization()`` already worked before
+    #643. This test guards the existing behaviour."""
+    app.use_authentication().add(MockNotAuthHandler())
+    app.use_authorization().default_policy += AuthenticatedRequirement()
+
+    @app.exception_handler(UnauthorizedError)
+    async def custom_unauthorized(self, request, exc):
+        return Response(401, content=TextContent("Custom unauthorized page"))
+
+    @auth()
+    @app.router.get("/")
+    async def home():
+        return None
+
+    await app(get_example_scope("GET", "/"), MockReceive(), MockSend())
+
+    assert app.response is not None
+    assert app.response.status == 401
+    body = await app.response.text()
+    assert body == "Custom unauthorized page"
+
+
+async def test_framework_defaults_still_apply_when_no_user_handler(app):
+    """Sanity: without a user-defined handler, the framework defaults installed
+    by ``use_authorization()`` must remain in effect."""
+    app.use_authentication().add(MockNotAuthHandler())
+    app.use_authorization().default_policy += AuthenticatedRequirement()
+
+    @auth()
+    @app.router.get("/")
+    async def home():
+        return None
+
+    await app(get_example_scope("GET", "/"), MockReceive(), MockSend())
+
+    assert app.response is not None
+    assert app.response.status == 401
+    # Framework default body for handle_unauthorized
+    body = await app.response.text()
+    assert body == "Unauthorized"
+
+    # And the registered handler is the framework's default
+    assert app.exceptions_handlers[UnauthorizedError] is handle_unauthorized
+    assert app.exceptions_handlers[ForbiddenError] is handle_forbidden
+    assert (
+        app.exceptions_handlers[AuthenticateChallenge]
+        is handle_authentication_challenge
+    )
 
 
 # endregion


### PR DESCRIPTION
## Summary

Fixes #643.

Calling `use_authorization()` overwrote any user-registered exception handler
for `UnauthorizedError`, `ForbiddenError`, `AuthenticateChallenge`, or
`RateLimitExceededError` if it had been registered before that call. The
framework defaults were installed via `self.exceptions_handlers.update({...})`,
which is order-dependent: handlers registered before `use_authorization()` were
silently dropped.

Switch to `setdefault` so the framework only installs a default when the user
has not already registered a handler for that exception type. Handlers
registered either before or after `use_authorization()` now win in both cases.

This matches the maintainer's stated intent in
[#538 (comment)](https://github.com/Neoteroi/BlackSheep/issues/538#issuecomment-2818424391):
> "You are absolutely correct that the current behavior is surprising and confusing and it should be improved. I prefer to still let the users define exception handlers both by type and by HTTP Status code [...] and therefore improve the code to handle both keys."

## Context

The reporter (#643) wrote:

```python
@app.exception_handler(404)
@app.exception_handler(500)
@app.exception_handler(403)
@app.exception_handler(401)
async def all_error(app, request, exc):
    ...
```

and expected this to fire for the 401 produced by `@auth()`. The intuitive
workaround posted by @bymoye is to register `@app.exception_handler(UnauthorizedError)`
because `UnauthorizedError` (from `guardpost`) is not a subclass of
`HTTPException`, so the status-code-based lookup in `get_http_exception_handler`
does not apply to it. That part is by-design.

However, even the intuitive workaround silently failed when the handler was
registered before `use_authorization()`, because
[`blacksheep/server/application.py:531`](https://github.com/Neoteroi/BlackSheep/blob/e601bdc/blacksheep/server/application.py#L531-L538)
calls `.update(...)` and clobbers it. That's the bug this PR fixes.

## Changes

- `blacksheep/server/application.py` — install the four authorization-related
  exception handlers with `setdefault` rather than `update`, with a comment
  pointing at #643.
- `tests/test_auth.py` — four new regression tests:
  - `test_user_unauthorized_handler_wins_when_registered_before_use_authorization`
    — fails on `origin/main`, passes on this branch.
  - `test_user_forbidden_handler_wins_when_registered_before_use_authorization`
    — same for `ForbiddenError` (403).
  - `test_user_unauthorized_handler_wins_when_registered_after_use_authorization`
    — sanity guard for the existing post-`use_authorization()` path.
  - `test_framework_defaults_still_apply_when_no_user_handler` — sanity guard
    that the framework defaults remain in effect when the user does not
    override them.
- `CHANGELOG.md` — entry under the unreleased `2.6.3` section.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/Neoteroi/BlackSheep.git /tmp/bs643 && cd /tmp/bs643
python3.11 -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt -q
make compile

cat > /tmp/repro_643.py <<'PY'
import sys, asyncio
sys.path.insert(0, "tests")
from blacksheep import Response, TextContent
from guardpost import AuthenticationHandler, Identity, UnauthorizedError
from utils.application import FakeApplication
from test_auth import MockSend, MockReceive, get_example_scope
from blacksheep.server.authorization import auth

class MockNotAuth(AuthenticationHandler):
    async def authenticate(self, ctx):
        ctx.identity = Identity({})
        return ctx.identity

async def main():
    app = FakeApplication(show_error_details=False)

    # User registers a custom handler BEFORE use_authorization (intuitive order)
    @app.exception_handler(UnauthorizedError)
    async def custom(self, req, exc):
        return Response(401, content=TextContent("Custom 401 page"))

    app.use_authentication().add(MockNotAuth())
    app.use_authorization()

    @auth()
    @app.router.get("/")
    async def home():
        return None

    await app.start()
    await app(get_example_scope("GET", "/"), MockReceive(), MockSend())
    print(await app.response.text())

asyncio.run(main())
PY

# --- BEFORE: origin/main, expect "Unauthorized" (custom handler dropped) ---
git checkout origin/main
make compile >/dev/null 2>&1
PYTHONPATH=. python /tmp/repro_643.py
# Expected: Unauthorized

# --- AFTER: this branch, expect "Custom 401 page" ---
git fetch https://github.com/jbbqqf/BlackSheep.git fix/643-user-exception-handlers-win-over-framework-defaults
git checkout FETCH_HEAD
make compile >/dev/null 2>&1
PYTHONPATH=. python /tmp/repro_643.py
# Expected: Custom 401 page
```

## What I ran locally

```
$ pytest tests/test_auth.py -v -k "user_unauthorized_handler or user_forbidden_handler or framework_defaults_still"
tests/test_auth.py::test_user_unauthorized_handler_wins_when_registered_before_use_authorization PASSED
tests/test_auth.py::test_user_forbidden_handler_wins_when_registered_before_use_authorization PASSED
tests/test_auth.py::test_user_unauthorized_handler_wins_when_registered_after_use_authorization PASSED
tests/test_auth.py::test_framework_defaults_still_apply_when_no_user_handler PASSED
====================== 4 passed, 43 deselected in 0.05s ========================

$ pytest tests/ -q
1921 passed, 1 skipped, 4 warnings in 5.74s
```

Stashing the `application.py` change and re-running the new tests produces
2 failures on `origin/main` (the BEFORE-registration cases), confirming the
tests are load-bearing regressions, not no-ops.

## Edge cases

| # | Scenario | User registers... | Expected | Verified by |
|---|---|---|---|---|
| 1 | `UnauthorizedError` handler registered **before** `use_authorization()` | `@app.exception_handler(UnauthorizedError)` | user handler wins | `test_user_unauthorized_handler_wins_when_registered_before_use_authorization` |
| 2 | `UnauthorizedError` handler registered **after** `use_authorization()` | same | user handler wins (unchanged) | `test_user_unauthorized_handler_wins_when_registered_after_use_authorization` |
| 3 | `ForbiddenError` handler registered **before** `use_authorization()` | `@app.exception_handler(ForbiddenError)` | user handler wins | `test_user_forbidden_handler_wins_when_registered_before_use_authorization` |
| 4 | No user handler | nothing | framework default applies (`"Unauthorized"`) | `test_framework_defaults_still_apply_when_no_user_handler` |
| 5 | Re-entrant call to `use_authorization()` | n/a | early-return at `if self._authorization_strategy` (line 517) — handlers untouched | existing path, unchanged |

## Risk / blast radius

- Only the four exception-type keys installed inside `use_authorization()` are
  affected: `AuthenticateChallenge`, `UnauthorizedError`, `ForbiddenError`,
  `RateLimitExceededError`. None of these are registered anywhere else in the
  source tree.
- The framework defaults still take effect when no user handler is registered
  (covered by `test_framework_defaults_still_apply_when_no_user_handler` and by
  the unchanged `test_authentication_challenge_response` /
  `test_authorization_default_requires_authenticated_user` tests).
- The full unit suite (1921 tests) passes on this branch.

```release-note
Fixes #643: `use_authorization()` no longer clobbers user-defined exception handlers for `UnauthorizedError` / `ForbiddenError` / `AuthenticateChallenge` / `RateLimitExceededError` registered before it.
```

---

*PR drafted with assistance from Claude Code (Anthropic). The change was
reviewed manually against BlackSheep's source. The reproducer block above
is the one I used during development; reviewers can paste it verbatim.*
