### PR TITLE
fix: never emit a wildcard Access-Control-Allow-Origin alongside credentials

### DIFF
--- a/blacksheep/server/cors.py
+++ b/blacksheep/server/cors.py
@@ -289,7 +289,14 @@ def get_cors_middleware(
             return _get_invalid_origin_response()
 
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-        origin_response = b"*" if "*" in policy.allow_origins else origin
+        # A literal "*" is invalid alongside credentials per the Fetch spec - browsers
+        # reject the response outright - so the specific request origin must be echoed
+        # back instead whenever credentials are allowed.
+        origin_response = (
+            b"*"
+            if "*" in policy.allow_origins and not policy.allow_credentials
+            else origin
+        )
 
         if next_request_method:
             # This is a preflight request;

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -473,6 +473,66 @@ async def test_cors_preflight_request_allow_credentials(app):
     assert response.headers.get_single(b"Access-Control-Allow-Credentials") == b"true"
 
 
+async def test_cors_preflight_request_allow_any_origin_with_credentials(app):
+    """
+    A literal "*" can't be combined with credentials - browsers reject the response
+    outright (Fetch spec) - so when both are configured, the request's own Origin must
+    be echoed back instead of "*", on both preflight and actual responses.
+    """
+    app.use_cors(
+        allow_methods="GET POST",
+        allow_origins="*",
+        allow_credentials=True,
+    )
+
+    @app.router.get("/")
+    async def home():
+        return text("Hello, World")
+
+    @app.router.post("/")
+    async def post_example(): ...
+
+    await app.start()
+
+    await app(
+        get_example_scope(
+            "OPTIONS",
+            "/",
+            [
+                (b"Origin", b"https://www.neoteroi.dev"),
+                (b"Access-Control-Request-Method", b"POST"),
+            ],
+        ),
+        MockReceive(),
+        MockSend(),
+    )
+
+    response = app.response
+    assert response.status == 200
+    assert (
+        response.headers.get_single(b"Access-Control-Allow-Origin")
+        == b"https://www.neoteroi.dev"
+    )
+    assert response.headers.get_single(b"Access-Control-Allow-Credentials") == b"true"
+
+    await app(
+        get_example_scope(
+            "GET",
+            "/",
+            [(b"Origin", b"https://www.neoteroi.dev")],
+        ),
+        MockReceive(),
+        MockSend(),
+    )
+
+    response = app.response
+    assert (
+        response.headers.get_single(b"Access-Control-Allow-Origin")
+        == b"https://www.neoteroi.dev"
+    )
+    assert response.headers.get_single(b"Access-Control-Allow-Credentials") == b"true"
+
+
 async def test_cors_preflight_request_allow_any(app):
     app.use_cors(allow_methods="*", allow_origins="*", allow_headers="*")
 


### PR DESCRIPTION
## Summary

When a CORS policy has `allow_origins="*"` and `allow_credentials=True`, the CORS middleware sends `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true`. Per the [Fetch spec](https://fetch.spec.whatwg.org/#http-access-control-allow-origin), a literal `*` for `Access-Control-Allow-Origin` is invalid when credentials are involved, and browsers reject the response outright for any `fetch`/`XMLHttpRequest` call made with `credentials: 'include'`. In practice this means a server configured this way returns a 200 with what looks like valid CORS headers, but every credentialed browser request against it silently fails at the network layer.

The middleware already has the correct fallback for named origins (echoing the specific origin instead of `*` when it's on the allow-list), it just wasn't applied to the wildcard case when credentials are also allowed.

## Fix

In `get_cors_middleware`, only use the literal `"*"` for `Access-Control-Allow-Origin` when credentials are *not* allowed; otherwise echo back the request's own `Origin`, same as the non-wildcard path already does. This applies to both the preflight response and the actual (non-OPTIONS) response.

## Test plan

- [x] Added `test_cors_preflight_request_allow_any_origin_with_credentials`, covering both the preflight and the actual GET response for a wildcard-origin + credentials-enabled policy
- [x] Reproduced the bug against `main` first (confirmed `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Credentials: true` were both sent) before applying the fix
- [x] Full test suite: `pytest tests/` → 1923 passed, 1 skipped
- [x] `black --check`, `isort --check-only`, `flake8` all clean on changed files