### PR TITLE
docs: correct misleading "encrypted" claims for signed-only auth cookies

### DIFF
--- a/blacksheep/server/authentication/cookie.py
+++ b/blacksheep/server/authentication/cookie.py
@@ -69,8 +69,10 @@ class CookieAuthentication(AuthenticationHandler):
         """
         Sets the cookie used for authentication. If a cookie is set, it is assumed that
         the user is recognized (authenticated). The passed value is serialized, meaning
-        signed and encrypted using the `itsdangerous.Serializer` associated with this
-        CookieAuthentication handler. A common scenario is that data is a dictionary
+        signed (not encrypted) using the `itsdangerous.Serializer` associated with this
+        CookieAuthentication handler - the cookie value protects against tampering, but
+        its contents remain readable to anyone with access to the cookie, so it should
+        not be used to store secrets. A common scenario is that data is a dictionary
         with claims describing the identity of the user (e.g. id_token claims).
 
         Parameters

--- a/blacksheep/server/authentication/oidc.py
+++ b/blacksheep/server/authentication/oidc.py
@@ -483,8 +483,10 @@ class CookiesOpenIDTokensHandler(OpenIDTokensHandler):
     ) -> Response:
         """
         Returns a redirect response that includes Set-Cookie headers
-        to configure an encrypted id_token and, optionally, also encrypted
-        access_token and refresh_token.
+        to configure a signed (not encrypted) id_token and, optionally, also
+        signed access_token and refresh_token. The cookie values are protected
+        against tampering, but remain readable to anyone with access to the
+        cookie.
         """
         response = redirect(original_path)
         await self._set_tokens_in_response(request, response, id_token, token_response)
@@ -588,8 +590,10 @@ class JWTOpenIDTokensHandler(OpenIDTokensHandler):
     ) -> Response:
         """
         Returns a redirect response that includes Set-Cookie headers
-        to configure an encrypted id_token and, optionally, also encrypted
-        access_token and refresh_token.
+        to configure a signed (not encrypted) id_token and, optionally, also
+        signed access_token and refresh_token. The cookie values are protected
+        against tampering, but remain readable to anyone with access to the
+        cookie.
         """
         response = html(
             self._get_html(
@@ -699,7 +703,10 @@ class TokenType(Enum):
 
 class CookiesTokensStore(TokensStore):
     """
-    A class that can store access and refresh tokens in encrypted form in cookies.
+    A class that can store access and refresh tokens in cookies, signed (not
+    encrypted) using `itsdangerous`. The cookie values are protected against
+    tampering, but remain readable to anyone with access to the cookie - do not
+    rely on this for confidentiality of the token contents.
 
     Beware that cookies size can be problematic when storing all information in cookies.
     If this is the case, consider implementing a type of `BaseTokensStore` that uses


### PR DESCRIPTION
## Summary

Several docstrings describe cookies set by `CookieAuthentication.set_cookie`, `CookiesTokensStore` (and the two OIDC result-handler methods that use it) as storing **encrypted** `id_token`/`access_token`/`refresh_token` values. They're actually only *signed*, via `get_serializer()` → `itsdangerous.URLSafeSerializer`. `URLSafeSerializer` provides integrity/tamper protection (an HMAC signature) but no confidentiality: the payload is base64-encoded plaintext, trivially decodable by anyone with access to the cookie (e.g. via browser devtools, a proxy, or a logged request).

This is just how `itsdangerous` works by default (same as Flask's session cookie, for reference) - not a code defect - but the docstrings actively claim the opposite of what happens, which could lead someone to store more sensitive data in these cookies than they otherwise would, believing the contents are hidden from the client.

## Change

Updated the docstrings in:
- `blacksheep/server/authentication/cookie.py` (`CookieAuthentication.set_cookie`)
- `blacksheep/server/authentication/oidc.py` (`CookiesTokensStore` class docstring, and both `get_success_response` methods that reference it)

to accurately describe the cookies as signed (not encrypted), and to note that contents remain readable to anyone with access to the cookie.

No behavior changes - this is a documentation-only fix.

## Test plan

- [x] Full test suite: `pytest tests/` → 1922 passed, 1 skipped (unchanged from baseline)
- [x] `black --check`, `isort --check-only`, `flake8` all clean on changed files