### PR TITLE
fix: honor accept_only_proxied_requests=False when known_networks is set

### DIFF
--- a/blacksheep/server/remotes/forwarding.py
+++ b/blacksheep/server/remotes/forwarding.py
@@ -62,10 +62,8 @@ class BaseForwardedHeadersMiddleware(TrustedHostsMiddleware, ABC):
         acceptd both requests that are proxied and requests that are hitting the web
         server directly.
         """
-        return (
-            self.accept_only_proxied_requests
-            and any(self.known_proxies)
-            or any(self.known_networks)
+        return self.accept_only_proxied_requests and (
+            any(self.known_proxies) or any(self.known_networks)
         )
 
     def validate_proxy_ip(self, proxy_ip: IPAddress) -> None:

--- a/tests/test_forwarding.py
+++ b/tests/test_forwarding.py
@@ -560,6 +560,46 @@ async def test_x_forwarded_headers_middleware_blocks_invalid_proxy_id_by_network
     assert called
 
 
+async def test_x_forwarded_headers_middleware_accepts_direct_requests_with_known_networks(
+    app: FakeApplication,
+):
+    """
+    accept_only_proxied_requests=False must skip proxy-ip validation entirely -
+    including for direct (non-proxied) requests - even when known_networks is
+    also configured. Due to Python operator precedence ('and' binds tighter than
+    'or'), `accept_only_proxied_requests and any(known_proxies) or
+    any(known_networks)` previously ignored accept_only_proxied_requests whenever
+    known_networks was non-empty, incorrectly rejecting direct requests.
+    """
+    app.middlewares.append(
+        XForwardedHeadersMiddleware(
+            known_networks=[ip_network("192.168.0.0/24")],
+            accept_only_proxied_requests=False,
+        )
+    )
+
+    called = False
+
+    @app.router.get("/")
+    async def home(request):
+        nonlocal called
+        called = True
+        return
+
+    scope = get_example_scope(
+        "GET",
+        "/",
+        extra_headers=[],
+        client=("203.0.113.196", 443),
+    )
+
+    await app(scope, MockReceive(), MockSend())
+
+    assert app.response is not None
+    assert app.response.status == 204
+    assert called
+
+
 async def test_forwarded_header_middleware(app: FakeApplication):
     app.middlewares.append(ForwardedHeadersMiddleware(allowed_hosts=["neoteroi.dev"]))
 


### PR DESCRIPTION
## Summary

`BaseForwardedHeadersMiddleware.should_validate_client_ip()` combines its conditions like this:

```python
return (
    self.accept_only_proxied_requests
    and any(self.known_proxies)
    or any(self.known_networks)
)
```

Since `and` binds tighter than `or` in Python, this is actually evaluated as:

```python
(self.accept_only_proxied_requests and any(self.known_proxies)) or any(self.known_networks)
```

So whenever `known_networks` is configured (non-empty), the method returns `True` **regardless** of `accept_only_proxied_requests` - contradicting the method's own docstring:

> If `accept_only_proxied_requests` is set to False, it means the server will accept both requests that are proxied and requests that are hitting the web server directly.

In practice, this means a server configured with `known_networks=[...]` and `accept_only_proxied_requests=False` (intending to accept both proxied and direct requests) will still validate the client IP against the known proxies/networks for every direct request, and reject any direct request whose IP isn't in that list with a 400 `Proxy IP not recognized` error - even though the developer explicitly asked for direct requests to be accepted too.

This doesn't reproduce when only `known_proxies` is used (the default), since in that case both terms of the `or` depend on `accept_only_proxied_requests` correctly. It's specific to the `known_networks` configuration.

## Fix

Parenthesize the intended grouping:

```python
return self.accept_only_proxied_requests and (
    any(self.known_proxies) or any(self.known_networks)
)
```

## Test plan

- [x] Reproduced the bug against `main` first (a direct, non-proxied request was rejected with 400 despite `accept_only_proxied_requests=False`) before applying the fix
- [x] Added `test_x_forwarded_headers_middleware_accepts_direct_requests_with_known_networks`, covering the `known_networks` + `accept_only_proxied_requests=False` combination
- [x] `pytest tests/test_forwarding.py` → 25 passed
- [x] Full test suite: `pytest tests/` → 1923 passed, 1 skipped
- [x] `black --check`, `isort --check-only`, `flake8` all clean on changed files